### PR TITLE
Accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@
 .idea/
 .DS_Store
 .claude
+.playwright-mcp

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem "tailwindcss-rails"
 gem "jbuilder"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.3.0)
+    bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
     bigdecimal (4.1.1)
     bindex (0.8.1)
@@ -383,6 +384,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
   brakeman
   bundler-audit
@@ -421,6 +423,7 @@ CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bcrypt (3.1.22) sha256=1f0072e88c2d705d94aff7f2c5cb02eb3f1ec4b8368671e19112527489f29032
   bcrypt_pbkdf (1.1.2) sha256=c2414c23ce66869b3eb9f643d6a3374d8322dfb5078125c82792304c10b94cf6
   bigdecimal (4.1.1) sha256=1c09efab961da45203c8316b0cdaec0ff391dfadb952dd459584b63ebf8054ca
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e

--- a/README.md
+++ b/README.md
@@ -58,11 +58,13 @@ bin/dev                                  # starts Puma (port 3000) + Tailwind wa
 
 To play, sign up at `/registration/new`. Practice mode (`/practice`) and image browsing are available without an account; starting/playing games requires sign-in.
 
+To manage the image library or edit past guesses through the UI, you need an admin account. Sign up normally, then promote yourself via `bin/rails c`: `User.find_by(email_address: "you@x").update(admin: true)`. On Heroku: `heroku run rails console`.
+
 ## Data model
 
 | Model | Belongs to | Has many | Key columns |
 |---|---|---|---|
-| `User` | — | `sessions`, `games` | `email_address`, `password_digest` |
+| `User` | — | `sessions`, `games` | `email_address`, `password_digest`, `admin` |
 | `Session` | `User` | — | `ip_address`, `user_agent` |
 | `Game` | `User` | `game_images`, `guesses`, `images` (through `game_images`) | `status`, `score`, `completed_at` |
 | `GameImage` | `Game`, `Image` | — | `position` (1–5) |
@@ -98,6 +100,8 @@ Any controller action touching a user-owned record must scope through `Current.u
 ```
 
 Same for nested writes: `Current.user.games.find(...).guesses.create!(...)`. Tests cover the cross-user 404 case in `test/controllers/games_controller_test.rb` and `guesses_controller_test.rb`.
+
+Mutating the image library, editing past guesses, and editing game metadata are admin-only. Game `score`, `status`, and `completed_at` are written by the backend during gameplay (results action) — the `/games/:id/edit` form exists only as an admin debug tool. Users can still destroy their own games. Use the `require_admin` before_action in `ApplicationController` for any future controller action that should be restricted to admins.
 
 ### Turbo + inline `<script>` tags
 

--- a/README.md
+++ b/README.md
@@ -56,18 +56,20 @@ bin/dev                                  # starts Puma (port 3000) + Tailwind wa
 
 `bin/dev` uses foreman — if you hit `foreman: not found`, run `gem install foreman`.
 
+To play, sign up at `/registration/new`. Practice mode (`/practice`) and image browsing are available without an account; starting/playing games requires sign-in.
+
 ## Data model
 
-```
-Image          Game            Guess
------          ----            -----
-url            status          game_id     -> Game
-latitude       score           image_id    -> Image
-longitude      completed_at    latitude    (user's guess)
-title                          longitude
-```
+| Model | Belongs to | Has many | Key columns |
+|---|---|---|---|
+| `User` | — | `sessions`, `games` | `email_address`, `password_digest` |
+| `Session` | `User` | — | `ip_address`, `user_agent` |
+| `Game` | `User` | `game_images`, `guesses`, `images` (through `game_images`) | `status`, `score`, `completed_at` |
+| `GameImage` | `Game`, `Image` | — | `position` (1–5) |
+| `Image` | — | `guesses`, `game_images` | `url`, `latitude`, `longitude`, `title` |
+| `Guess` | `Game`, `Image` | — | `latitude`, `longitude` (player's pick) |
 
-Each guess belongs to one game and one image. A game has many guesses (and, through those, many images). The image holds the "correct answer" lat/lng; the guess holds the player's lat/lng.
+Each game materializes a fixed 5-image set on creation (`game_images` rows with positions 1–5), so the same game can later be replayed by a challenger against the identical image sequence. The `Image` row holds the correct answer; the `Guess` row holds the player's pick.
 
 ## Seed data
 
@@ -78,6 +80,32 @@ Each guess belongs to one game and one image. A game has many guesses (and, thro
 | `bin/rails db:seed`        | Adds new records, skips existing                                    |
 | `bin/rails db:reset`       | Destroys DB -> recreates -> migrates -> seeds (wipes Games/Guesses too) |
 | `bin/rails db:seed:replant`| Truncates tables, then seeds (keeps schema)                         |
+
+## Conventions
+
+A few patterns that aren't obvious from the code but are easy to break.
+
+### Auth scoping (security-critical)
+
+Any controller action touching a user-owned record must scope through `Current.user`, never `Model.find` directly. So:
+
+```ruby
+# Right — wrong-owner request returns 404 because the scope filters it out
+@game = Current.user.games.find(params[:id])
+
+# Wrong — silently exposes other users' games
+@game = Game.find(params[:id])
+```
+
+Same for nested writes: `Current.user.games.find(...).guesses.create!(...)`. Tests cover the cross-user 404 case in `test/controllers/games_controller_test.rb` and `guesses_controller_test.rb`.
+
+### Turbo + inline `<script>` tags
+
+Turbo Drive swaps the body in place on link clicks, which means inline scripts that initialize JS libraries (e.g., MapLibre on `/images/map`) don't re-run. Links pointing to such pages need `data: { turbo: false }` to force a full page load.
+
+### Wikidata seeder
+
+`db/seeds.rb` uses **`SERVICE bd:sample`** for random sampling — not `ORDER BY RAND()` or hashed orderings, both of which time out at scale when unioning multiple landform types. `bd:sample` accepts only a single triple pattern, so the seeder samples by `wdt:P31` (instance-of) inside the `SERVICE` block and joins `wdt:P18`/`wdt:P625` outside. Over-sampling (`limit 2000`) is intentional — only ~5–20% of any landform type has both an image and coordinates. Filenames are filtered for non-photo contamination (satellite imagery, maps); when adding new landform types, spot-check for new junk patterns.
 
 ## Contributing
 

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,0 +1,16 @@
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      set_current_user || reject_unauthorized_connection
+    end
+
+    private
+      def set_current_user
+        if session = Session.find_by(id: cookies.signed[:session_id])
+          self.current_user = session.user
+        end
+      end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  include Authentication
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,4 +5,15 @@ class ApplicationController < ActionController::Base
 
   # Changes to the importmap will invalidate the etag for HTML responses
   stale_when_importmap_changes
+
+  helper_method :admin?
+
+  private
+    def admin?
+      authenticated? && Current.user.admin?
+    end
+
+    def require_admin
+      redirect_to root_path, alert: "Admin access required." unless admin?
+    end
 end

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -1,0 +1,52 @@
+module Authentication
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :require_authentication
+    helper_method :authenticated?
+  end
+
+  class_methods do
+    def allow_unauthenticated_access(**options)
+      skip_before_action :require_authentication, **options
+    end
+  end
+
+  private
+    def authenticated?
+      resume_session
+    end
+
+    def require_authentication
+      resume_session || request_authentication
+    end
+
+    def resume_session
+      Current.session ||= find_session_by_cookie
+    end
+
+    def find_session_by_cookie
+      Session.find_by(id: cookies.signed[:session_id]) if cookies.signed[:session_id]
+    end
+
+    def request_authentication
+      session[:return_to_after_authenticating] = request.url
+      redirect_to new_session_path
+    end
+
+    def after_authentication_url
+      session.delete(:return_to_after_authenticating) || root_url
+    end
+
+    def start_new_session_for(user)
+      user.sessions.create!(user_agent: request.user_agent, ip_address: request.remote_ip).tap do |session|
+        Current.session = session
+        cookies.signed.permanent[:session_id] = { value: session.id, httponly: true, same_site: :lax }
+      end
+    end
+
+    def terminate_session
+      Current.session.destroy
+      cookies.delete(:session_id)
+    end
+end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,21 +1,23 @@
 class GamesController < ApplicationController
+  TOTAL_ROUNDS = 5
+
   before_action :set_game, only: %i[ show edit update destroy results ]
 
   # GET /games or /games.json
   def index
-    @games = Game.includes(:guesses).order(created_at: :desc)
-    @total_rounds = 5
+    @games = Current.user.games.includes(:guesses).order(created_at: :desc)
+    @total_rounds = TOTAL_ROUNDS
   end
 
   # GET /games/1 or /games/1.json
   def show
-    @total_rounds = 5
+    @total_rounds = TOTAL_ROUNDS
     @round = @game.guesses.count + 1
     if @round > @total_rounds
       redirect_to results_game_path(@game) and return
     end
-    guessed_ids = @game.guesses.pluck(:image_id)
-    @image = Image.where.not(id: guessed_ids).order("RANDOM()").first
+
+    @image = @game.game_images.includes(:image).find_by(position: @round)&.image
 
     if @image.nil?
       redirect_to results_game_path(@game) and return
@@ -24,7 +26,7 @@ class GamesController < ApplicationController
 
   # GET /games/new
   def new
-    @game = Game.new
+    @game = Current.user.games.new
   end
 
   # GET /games/1/edit
@@ -33,16 +35,28 @@ class GamesController < ApplicationController
 
   # POST /games or /games.json
   def create
-    @game = Game.new(status: "in_progress")
+    @game = Current.user.games.new(status: "in_progress")
+    image_ids = Image.order("RANDOM()").limit(TOTAL_ROUNDS).pluck(:id)
+
+    if image_ids.size < TOTAL_ROUNDS
+      redirect_to root_path, alert: "Not enough images to start a game." and return
+    end
+
+    Game.transaction do
+      @game.save!
+      image_ids.each_with_index do |image_id, idx|
+        @game.game_images.create!(image_id: image_id, position: idx + 1)
+      end
+    end
 
     respond_to do |format|
-      if @game.save
-        format.html { redirect_to @game }
-        format.json { render :show, status: :created, location: @game }
-      else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @game.errors, status: :unprocessable_entity }
-      end
+      format.html { redirect_to @game }
+      format.json { render :show, status: :created, location: @game }
+    end
+  rescue ActiveRecord::RecordInvalid
+    respond_to do |format|
+      format.html { render :new, status: :unprocessable_entity }
+      format.json { render json: @game.errors, status: :unprocessable_entity }
     end
   end
 
@@ -71,7 +85,6 @@ class GamesController < ApplicationController
 
   # GET /games/1/results
   def results
-    total_rounds = 5
     guesses = @game.guesses.includes(:image).order(:created_at)
 
     @rounds = guesses.map do |guess|
@@ -83,7 +96,7 @@ class GamesController < ApplicationController
     end
 
     @total_distance_km = @rounds.sum { |r| r[:distance_km] }
-    @total_rounds = total_rounds
+    @total_rounds = TOTAL_ROUNDS
 
     if @game.status != "completed"
       @game.update!(status: "completed", score: @total_distance_km, completed_at: Time.current)
@@ -93,7 +106,7 @@ class GamesController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_game
-      @game = Game.find(params.expect(:id))
+      @game = Current.user.games.find(params.expect(:id))
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,6 +1,7 @@
 class GamesController < ApplicationController
   TOTAL_ROUNDS = 5
 
+  before_action :require_admin, only: %i[ edit update ]
   before_action :set_game, only: %i[ show edit update destroy results ]
 
   # GET /games or /games.json

--- a/app/controllers/guesses_controller.rb
+++ b/app/controllers/guesses_controller.rb
@@ -1,4 +1,5 @@
 class GuessesController < ApplicationController
+  before_action :require_admin, only: %i[ new edit update destroy ]
   before_action :set_guess, only: %i[ show edit update destroy ]
 
   # GET /guesses or /guesses.json

--- a/app/controllers/guesses_controller.rb
+++ b/app/controllers/guesses_controller.rb
@@ -3,7 +3,7 @@ class GuessesController < ApplicationController
 
   # GET /guesses or /guesses.json
   def index
-    @guesses = Guess.all
+    @guesses = Guess.where(game: Current.user.games)
   end
 
   # GET /guesses/1 or /guesses/1.json
@@ -21,7 +21,8 @@ class GuessesController < ApplicationController
 
   # POST /guesses or /guesses.json
   def create
-    @guess = Guess.new(guess_params)
+    game = Current.user.games.find(params.dig(:guess, :game_id))
+    @guess = game.guesses.new(guess_params.except(:game_id))
 
     respond_to do |format|
       if @guess.save
@@ -60,7 +61,7 @@ class GuessesController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_guess
-      @guess = Guess.find(params.expect(:id))
+      @guess = Guess.where(game: Current.user.games).find(params.expect(:id))
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,6 @@
 class HomeController < ApplicationController
+  allow_unauthenticated_access only: %i[ start ]
+
   def start
   end
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,5 +1,6 @@
 class ImagesController < ApplicationController
   allow_unauthenticated_access only: %i[ index show map ]
+  before_action :require_admin, only: %i[ new create edit update destroy ]
   before_action :set_image, only: %i[ show edit update destroy ]
 
   # GET /images or /images.json

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,4 +1,5 @@
 class ImagesController < ApplicationController
+  allow_unauthenticated_access only: %i[ index show map ]
   before_action :set_image, only: %i[ show edit update destroy ]
 
   # GET /images or /images.json

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,0 +1,35 @@
+class PasswordsController < ApplicationController
+  allow_unauthenticated_access
+  before_action :set_user_by_token, only: %i[ edit update ]
+  rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_password_path, alert: "Try again later." }
+
+  def new
+  end
+
+  def create
+    if user = User.find_by(email_address: params[:email_address])
+      PasswordsMailer.reset(user).deliver_later
+    end
+
+    redirect_to new_session_path, notice: "Password reset instructions sent (if user with that email address exists)."
+  end
+
+  def edit
+  end
+
+  def update
+    if @user.update(params.permit(:password, :password_confirmation))
+      @user.sessions.destroy_all
+      redirect_to new_session_path, notice: "Password has been reset."
+    else
+      redirect_to edit_password_path(params[:token]), alert: "Passwords did not match."
+    end
+  end
+
+  private
+    def set_user_by_token
+      @user = User.find_by_password_reset_token!(params[:token])
+    rescue ActiveSupport::MessageVerifier::InvalidSignature
+      redirect_to new_password_path, alert: "Password reset link is invalid or has expired."
+    end
+end

--- a/app/controllers/practice_controller.rb
+++ b/app/controllers/practice_controller.rb
@@ -1,4 +1,6 @@
 class PracticeController < ApplicationController
+  allow_unauthenticated_access only: %i[ show ]
+
   def show
     @image = Image.order("RANDOM()").first
 

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,22 @@
+class RegistrationsController < ApplicationController
+  allow_unauthenticated_access only: %i[ new create ]
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(registration_params)
+    if @user.save
+      start_new_session_for @user
+      redirect_to after_authentication_url, notice: "Welcome!"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+    def registration_params
+      params.expect(user: [ :email_address, :password, :password_confirmation ])
+    end
+end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -11,6 +11,7 @@ class RegistrationsController < ApplicationController
       start_new_session_for @user
       redirect_to after_authentication_url, notice: "Welcome!"
     else
+      flash.now[:alert] = @user.errors.full_messages.first
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,21 @@
+class SessionsController < ApplicationController
+  allow_unauthenticated_access only: %i[ new create ]
+  rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_path, alert: "Try again later." }
+
+  def new
+  end
+
+  def create
+    if user = User.authenticate_by(params.permit(:email_address, :password))
+      start_new_session_for user
+      redirect_to after_authentication_url
+    else
+      redirect_to new_session_path, alert: "Try another email address or password."
+    end
+  end
+
+  def destroy
+    terminate_session
+    redirect_to new_session_path, status: :see_other
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,7 +8,7 @@ class SessionsController < ApplicationController
   def create
     if user = User.authenticate_by(params.permit(:email_address, :password))
       start_new_session_for user
-      redirect_to after_authentication_url
+      redirect_to after_authentication_url, notice: "Signed in."
     else
       redirect_to new_session_path, alert: "Try another email address or password."
     end
@@ -16,6 +16,6 @@ class SessionsController < ApplicationController
 
   def destroy
     terminate_session
-    redirect_to new_session_path, status: :see_other
+    redirect_to new_session_path, status: :see_other, notice: "Signed out."
   end
 end

--- a/app/mailers/passwords_mailer.rb
+++ b/app/mailers/passwords_mailer.rb
@@ -1,0 +1,6 @@
+class PasswordsMailer < ApplicationMailer
+  def reset(user)
+    @user = user
+    mail subject: "Reset your password", to: user.email_address
+  end
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,4 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :session
+  delegate :user, to: :session, allow_nil: true
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,4 +1,6 @@
 class Game < ApplicationRecord
+  belongs_to :user
   has_many :guesses, dependent: :destroy
-  has_many :images, through: :guesses
+  has_many :game_images, -> { order(:position) }, dependent: :destroy
+  has_many :images, through: :game_images
 end

--- a/app/models/game_image.rb
+++ b/app/models/game_image.rb
@@ -1,0 +1,4 @@
+class GameImage < ApplicationRecord
+  belongs_to :game
+  belongs_to :image
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,3 +1,4 @@
 class Image < ApplicationRecord
   has_many :guesses, dependent: :destroy
+  has_many :game_images, dependent: :destroy
 end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,0 +1,3 @@
+class Session < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,11 @@
+class User < ApplicationRecord
+  has_secure_password
+  has_many :sessions, dependent: :destroy
+  has_many :games, dependent: :destroy
+
+  normalizes :email_address, with: ->(e) { e.strip.downcase }
+
+  validates :email_address, presence: true, uniqueness: true,
+                            format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :password, length: { minimum: 8 }, allow_nil: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,8 @@ class User < ApplicationRecord
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }
 
-  validates :email_address, presence: true, uniqueness: true,
+  validates :email_address, presence: true,
+                            uniqueness: { message: "is invalid" },
                             format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :password, length: { minimum: 8 }, allow_nil: true
 end

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -13,7 +13,9 @@
           <%= render game %>
           <div class="w-full sm:w-auto flex flex-col sm:flex-row space-x-2 space-y-2">
             <%= link_to "Show", game, class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
-            <%= link_to "Edit", edit_game_path(game), class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+            <% if admin? %>
+              <%= link_to "Edit", edit_game_path(game), class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+            <% end %>
             <%= button_to "Destroy", game, method: :delete, class: "w-full sm:w-auto rounded-md px-3.5 py-2.5 text-white bg-red-600 hover:bg-red-500 font-medium cursor-pointer", data: { turbo_confirm: "Are you sure?" } %>
           </div>
         </div>

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -1,10 +1,6 @@
 <% content_for :title, "Games" %>
 
 <div class="w-full">
-  <% if notice.present? %>
-    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-md inline-block" id="notice"><%= notice %></p>
-  <% end %>
-
   <div class="flex justify-between items-center">
     <h1 class="font-bold text-4xl">Games</h1>
     <%= link_to "New game", new_game_path, class: "rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white block font-medium" %>

--- a/app/views/guesses/index.html.erb
+++ b/app/views/guesses/index.html.erb
@@ -3,7 +3,9 @@
 <div class="w-full">
   <div class="flex justify-between items-center">
     <h1 class="font-bold text-4xl">Guesses</h1>
-    <%= link_to "New guess", new_guess_path, class: "rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white block font-medium" %>
+    <% if admin? %>
+      <%= link_to "New guess", new_guess_path, class: "rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white block font-medium" %>
+    <% end %>
   </div>
 
   <div id="guesses" class="min-w-full divide-y divide-gray-200 space-y-5">
@@ -13,8 +15,10 @@
           <%= render guess %>
           <div class="w-full sm:w-auto flex flex-col sm:flex-row space-x-2 space-y-2">
             <%= link_to "Show", guess, class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
-            <%= link_to "Edit", edit_guess_path(guess), class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
-            <%= button_to "Destroy", guess, method: :delete, class: "w-full sm:w-auto rounded-md px-3.5 py-2.5 text-white bg-red-600 hover:bg-red-500 font-medium cursor-pointer", data: { turbo_confirm: "Are you sure?" } %>
+            <% if admin? %>
+              <%= link_to "Edit", edit_guess_path(guess), class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+              <%= button_to "Destroy", guess, method: :delete, class: "w-full sm:w-auto rounded-md px-3.5 py-2.5 text-white bg-red-600 hover:bg-red-500 font-medium cursor-pointer", data: { turbo_confirm: "Are you sure?" } %>
+            <% end %>
           </div>
         </div>
       <% end %>

--- a/app/views/guesses/index.html.erb
+++ b/app/views/guesses/index.html.erb
@@ -1,10 +1,6 @@
 <% content_for :title, "Guesses" %>
 
 <div class="w-full">
-  <% if notice.present? %>
-    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-md inline-block" id="notice"><%= notice %></p>
-  <% end %>
-
   <div class="flex justify-between items-center">
     <h1 class="font-bold text-4xl">Guesses</h1>
     <%= link_to "New guess", new_guess_path, class: "rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white block font-medium" %>

--- a/app/views/guesses/show.html.erb
+++ b/app/views/guesses/show.html.erb
@@ -1,10 +1,6 @@
 <% content_for :title, "Showing guess" %>
 
 <div class="md:w-2/3 w-full">
-  <% if notice.present? %>
-    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-md inline-block" id="notice"><%= notice %></p>
-  <% end %>
-
   <h1 class="font-bold text-4xl">Showing guess</h1>
 
   <%= render @guess %>

--- a/app/views/guesses/show.html.erb
+++ b/app/views/guesses/show.html.erb
@@ -5,7 +5,9 @@
 
   <%= render @guess %>
 
-  <%= link_to "Edit this guess", edit_guess_path(@guess), class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
-  <%= link_to "Back to guesses", guesses_path, class: "w-full sm:w-auto text-center mt-2 sm:mt-0 sm:ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
-  <%= button_to "Destroy this guess", @guess, method: :delete, form_class: "sm:inline-block mt-2 sm:mt-0 sm:ml-2", class: "w-full rounded-md px-3.5 py-2.5 text-white bg-red-600 hover:bg-red-500 font-medium cursor-pointer", data: { turbo_confirm: "Are you sure?" } %>
+  <%= link_to "Back to guesses", guesses_path, class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+  <% if admin? %>
+    <%= link_to "Edit this guess", edit_guess_path(@guess), class: "w-full sm:w-auto text-center mt-2 sm:mt-0 sm:ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+    <%= button_to "Destroy this guess", @guess, method: :delete, form_class: "sm:inline-block mt-2 sm:mt-0 sm:ml-2", class: "w-full rounded-md px-3.5 py-2.5 text-white bg-red-600 hover:bg-red-500 font-medium cursor-pointer", data: { turbo_confirm: "Are you sure?" } %>
+  <% end %>
 </div>

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -5,7 +5,9 @@
     <h1 class="font-bold text-4xl">Images</h1>
     <div class="flex space-x-2">
       <%= link_to "Map view", map_images_path, class: "rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 font-medium", data: { turbo: false } %>
-      <%= link_to "New image", new_image_path, class: "rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white font-medium" %>
+      <% if admin? %>
+        <%= link_to "New image", new_image_path, class: "rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white font-medium" %>
+      <% end %>
     </div>
   </div>
 
@@ -16,8 +18,10 @@
           <%= render image %>
           <div class="w-full sm:w-auto flex flex-col sm:flex-row space-x-2 space-y-2">
             <%= link_to "Show", image, class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
-            <%= link_to "Edit", edit_image_path(image), class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
-            <%= button_to "Destroy", image, method: :delete, class: "w-full sm:w-auto rounded-md px-3.5 py-2.5 text-white bg-red-600 hover:bg-red-500 font-medium cursor-pointer", data: { turbo_confirm: "Are you sure?" } %>
+            <% if admin? %>
+              <%= link_to "Edit", edit_image_path(image), class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+              <%= button_to "Destroy", image, method: :delete, class: "w-full sm:w-auto rounded-md px-3.5 py-2.5 text-white bg-red-600 hover:bg-red-500 font-medium cursor-pointer", data: { turbo_confirm: "Are you sure?" } %>
+            <% end %>
           </div>
         </div>
       <% end %>

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -1,10 +1,6 @@
 <% content_for :title, "Images" %>
 
 <div class="w-full">
-  <% if notice.present? %>
-    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-md inline-block" id="notice"><%= notice %></p>
-  <% end %>
-
   <div class="flex justify-between items-center">
     <h1 class="font-bold text-4xl">Images</h1>
     <div class="flex space-x-2">

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -5,7 +5,9 @@
 
   <%= render @image %>
 
-  <%= link_to "Edit this image", edit_image_path(@image), class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
-  <%= link_to "Back to images", images_path, class: "w-full sm:w-auto text-center mt-2 sm:mt-0 sm:ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
-  <%= button_to "Destroy this image", @image, method: :delete, form_class: "sm:inline-block mt-2 sm:mt-0 sm:ml-2", class: "w-full rounded-md px-3.5 py-2.5 text-white bg-red-600 hover:bg-red-500 font-medium cursor-pointer", data: { turbo_confirm: "Are you sure?" } %>
+  <%= link_to "Back to images", images_path, class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+  <% if admin? %>
+    <%= link_to "Edit this image", edit_image_path(@image), class: "w-full sm:w-auto text-center mt-2 sm:mt-0 sm:ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+    <%= button_to "Destroy this image", @image, method: :delete, form_class: "sm:inline-block mt-2 sm:mt-0 sm:ml-2", class: "w-full rounded-md px-3.5 py-2.5 text-white bg-red-600 hover:bg-red-500 font-medium cursor-pointer", data: { turbo_confirm: "Are you sure?" } %>
+  <% end %>
 </div>

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -1,10 +1,6 @@
 <% content_for :title, "Showing image" %>
 
 <div class="md:w-2/3 w-full">
-  <% if notice.present? %>
-    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-md inline-block" id="notice"><%= notice %></p>
-  <% end %>
-
   <h1 class="font-bold text-4xl">Showing image</h1>
 
   <%= render @image %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,27 @@
   </head>
 
   <body>
-    <main class="container mx-auto mt-28 px-5 flex">
+    <nav class="container mx-auto px-5 pt-5 flex justify-between items-center text-sm">
+      <%= link_to "Landscape Guessr", root_path, class: "font-bold" %>
+      <div class="flex items-center gap-3">
+        <% if authenticated? %>
+          <span class="text-gray-600 hidden sm:inline"><%= Current.user.email_address %></span>
+          <%= button_to "Sign out", session_path, method: :delete,
+                class: "rounded-md px-3 py-1.5 bg-gray-100 hover:bg-gray-50 font-medium border border-gray-200 cursor-pointer" %>
+        <% else %>
+          <%= link_to "Sign in", new_session_path, class: "rounded-md px-3 py-1.5 bg-gray-100 hover:bg-gray-50 font-medium border border-gray-200" %>
+          <%= link_to "Sign up", new_registration_path, class: "rounded-md px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white font-medium" %>
+        <% end %>
+      </div>
+    </nav>
+
+    <main class="container mx-auto mt-20 px-5 flex flex-col">
+      <% if notice = flash[:notice] %>
+        <p class="py-2 px-3 mb-5 bg-green-50 text-green-600 font-medium rounded-md self-start" id="notice"><%= notice %></p>
+      <% end %>
+      <% if alert = flash[:alert] %>
+        <p class="py-2 px-3 mb-5 bg-red-50 text-red-600 font-medium rounded-md self-start" id="alert"><%= alert %></p>
+      <% end %>
       <%= yield %>
     </main>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,12 +38,12 @@
       </div>
     </nav>
 
-    <main class="container mx-auto mt-20 px-5 flex flex-col">
+    <main class="container mx-auto mt-20 px-5">
       <% if notice = flash[:notice] %>
-        <p class="py-2 px-3 mb-5 bg-green-50 text-green-600 font-medium rounded-md self-start" id="notice"><%= notice %></p>
+        <p class="py-2 px-3 mb-5 bg-green-50 text-green-600 font-medium rounded-md mx-auto md:w-2/3 w-full" id="notice"><%= notice %></p>
       <% end %>
       <% if alert = flash[:alert] %>
-        <p class="py-2 px-3 mb-5 bg-red-50 text-red-600 font-medium rounded-md self-start" id="alert"><%= alert %></p>
+        <p class="py-2 px-3 mb-5 bg-red-50 text-red-600 font-medium rounded-md mx-auto md:w-2/3 w-full" id="alert"><%= alert %></p>
       <% end %>
       <%= yield %>
     </main>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,0 +1,21 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <% if alert = flash[:alert] %>
+    <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
+  <% end %>
+
+  <h1 class="font-bold text-4xl">Update your password</h1>
+
+  <%= form_with url: password_path(params[:token]), method: :put, class: "contents" do |form| %>
+    <div class="my-5">
+      <%= form.password_field :password, required: true, autocomplete: "new-password", placeholder: "Enter new password", maxlength: 72, class: "block shadow-sm rounded-md border border-gray-400 focus:outline-solid focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
+    </div>
+
+    <div class="my-5">
+      <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: "Repeat new password", maxlength: 72, class: "block shadow-sm rounded-md border border-gray-400 focus:outline-solid focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
+    </div>
+
+    <div class="inline">
+      <%= form.submit "Save", class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white inline-block font-medium cursor-pointer" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,8 +1,4 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <% if alert = flash[:alert] %>
-    <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
-  <% end %>
-
   <h1 class="font-bold text-4xl">Update your password</h1>
 
   <%= form_with url: password_path(params[:token]), method: :put, class: "contents" do |form| %>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,0 +1,17 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <% if alert = flash[:alert] %>
+    <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
+  <% end %>
+
+  <h1 class="font-bold text-4xl">Forgot your password?</h1>
+
+  <%= form_with url: passwords_path, class: "contents" do |form| %>
+    <div class="my-5">
+      <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address], class: "block shadow-sm rounded-md border border-gray-400 focus:outline-solid focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
+    </div>
+
+    <div class="inline">
+      <%= form.submit "Email reset instructions", class: "w-full sm:w-auto text-center rounded-lg px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white inline-block font-medium cursor-pointer" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,8 +1,4 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <% if alert = flash[:alert] %>
-    <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
-  <% end %>
-
   <h1 class="font-bold text-4xl">Forgot your password?</h1>
 
   <%= form_with url: passwords_path, class: "contents" do |form| %>

--- a/app/views/passwords_mailer/reset.html.erb
+++ b/app/views/passwords_mailer/reset.html.erb
@@ -1,0 +1,6 @@
+<p>
+  You can reset your password on
+  <%= link_to "this password reset page", edit_password_url(@user.password_reset_token) %>.
+
+  This link will expire in <%= distance_of_time_in_words(0, @user.password_reset_token_expires_in) %>.
+</p>

--- a/app/views/passwords_mailer/reset.text.erb
+++ b/app/views/passwords_mailer/reset.text.erb
@@ -1,0 +1,4 @@
+You can reset your password on
+<%= edit_password_url(@user.password_reset_token) %>
+
+This link will expire in <%= distance_of_time_in_words(0, @user.password_reset_token_expires_in) %>.

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -1,0 +1,40 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <% if alert = flash[:alert] %>
+    <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
+  <% end %>
+
+  <h1 class="font-bold text-4xl">Sign up</h1>
+
+  <%= form_with model: @user, url: registration_path, class: "contents" do |form| %>
+    <% if @user.errors.any? %>
+      <div class="py-2 px-3 my-5 bg-red-50 text-red-500 rounded-lg">
+        <ul class="list-disc list-inside text-sm">
+          <% @user.errors.full_messages.each do |msg| %>
+            <li><%= msg %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <div class="my-5">
+      <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "email", placeholder: "Enter your email address", class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
+    </div>
+
+    <div class="my-5">
+      <%= form.password_field :password, required: true, autocomplete: "new-password", placeholder: "Choose a password (min 8 chars)", maxlength: 72, class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
+    </div>
+
+    <div class="my-5">
+      <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: "Confirm password", maxlength: 72, class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
+    </div>
+
+    <div class="inline">
+      <%= form.submit "Sign up", class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white inline-block font-medium cursor-pointer" %>
+    </div>
+  <% end %>
+
+  <p class="mt-6 text-sm text-gray-600">
+    Already have an account?
+    <%= link_to "Sign in", new_session_path, class: "text-blue-600 underline hover:no-underline" %>
+  </p>
+</div>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -1,21 +1,7 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <% if alert = flash[:alert] %>
-    <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
-  <% end %>
-
   <h1 class="font-bold text-4xl">Sign up</h1>
 
   <%= form_with model: @user, url: registration_path, class: "contents" do |form| %>
-    <% if @user.errors.any? %>
-      <div class="py-2 px-3 my-5 bg-red-50 text-red-500 rounded-lg">
-        <ul class="list-disc list-inside text-sm">
-          <% @user.errors.full_messages.each do |msg| %>
-            <li><%= msg %></li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
-
     <div class="my-5">
       <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "email", placeholder: "Enter your email address", class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
     </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,12 +1,4 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <% if alert = flash[:alert] %>
-    <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
-  <% end %>
-
-  <% if notice = flash[:notice] %>
-    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
-  <% end %>
-
   <h1 class="font-bold text-4xl">Sign in</h1>
 
   <%= form_with url: session_url, class: "contents" do |form| %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,36 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <% if alert = flash[:alert] %>
+    <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
+  <% end %>
+
+  <% if notice = flash[:notice] %>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+  <% end %>
+
+  <h1 class="font-bold text-4xl">Sign in</h1>
+
+  <%= form_with url: session_url, class: "contents" do |form| %>
+    <div class="my-5">
+      <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address], class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
+    </div>
+
+    <div class="my-5">
+      <%= form.password_field :password, required: true, autocomplete: "current-password", placeholder: "Enter your password", maxlength: 72, class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
+    </div>
+
+    <div class="col-span-6 sm:flex sm:items-center sm:gap-4">
+      <div class="inline">
+        <%= form.submit "Sign in", class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white inline-block font-medium cursor-pointer" %>
+      </div>
+
+      <div class="mt-4 text-sm text-gray-500 sm:mt-0">
+        <%= link_to "Forgot password?", new_password_path, class: "text-gray-700 underline hover:no-underline" %>
+      </div>
+    </div>
+  <% end %>
+
+  <p class="mt-6 text-sm text-gray-600">
+    Don't have an account?
+    <%= link_to "Sign up", new_registration_path, class: "text-blue-600 underline hover:no-underline" %>
+  </p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Rails.application.routes.draw do
   root "home#start"
 
+  resource :session
+  resources :passwords, param: :token
+  resource :registration, only: %i[ new create ]
+
   resources :guesses
   resources :games do
     member { get :results }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   root "home#start"
 
-  resource :session
-  resources :passwords, param: :token
+  resource :session, only: %i[ new create destroy ]
+  resources :passwords, param: :token, only: %i[ new create edit update ]
   resource :registration, only: %i[ new create ]
 
   resources :guesses

--- a/db/migrate/20260424000001_create_users.rb
+++ b/db/migrate/20260424000001_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[8.1]
+  def change
+    create_table :users do |t|
+      t.string :email_address, null: false
+      t.string :password_digest, null: false
+
+      t.timestamps
+    end
+
+    add_index :users, :email_address, unique: true
+  end
+end

--- a/db/migrate/20260424000002_create_sessions.rb
+++ b/db/migrate/20260424000002_create_sessions.rb
@@ -1,0 +1,11 @@
+class CreateSessions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :sessions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :ip_address
+      t.string :user_agent
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260424000003_add_user_to_games.rb
+++ b/db/migrate/20260424000003_add_user_to_games.rb
@@ -1,0 +1,11 @@
+class AddUserToGames < ActiveRecord::Migration[8.1]
+  def up
+    execute "DELETE FROM guesses"
+    execute "DELETE FROM games"
+    add_reference :games, :user, null: false, foreign_key: true, index: true
+  end
+
+  def down
+    remove_reference :games, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20260424000004_create_game_images.rb
+++ b/db/migrate/20260424000004_create_game_images.rb
@@ -1,0 +1,13 @@
+class CreateGameImages < ActiveRecord::Migration[8.1]
+  def change
+    create_table :game_images do |t|
+      t.references :game, null: false, foreign_key: true
+      t.references :image, null: false, foreign_key: true
+      t.integer :position, null: false
+
+      t.timestamps
+    end
+
+    add_index :game_images, [ :game_id, :position ], unique: true
+  end
+end

--- a/db/migrate/20260427000001_add_admin_to_users.rb
+++ b/db/migrate/20260427000001_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :admin, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_17_192424) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_24_000004) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "game_images", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "game_id", null: false
+    t.bigint "image_id", null: false
+    t.integer "position", null: false
+    t.datetime "updated_at", null: false
+    t.index ["game_id", "position"], name: "index_game_images_on_game_id_and_position", unique: true
+    t.index ["game_id"], name: "index_game_images_on_game_id"
+    t.index ["image_id"], name: "index_game_images_on_image_id"
+  end
 
   create_table "games", force: :cascade do |t|
     t.datetime "completed_at"
@@ -20,6 +31,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_17_192424) do
     t.integer "score"
     t.string "status"
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_games_on_user_id"
   end
 
   create_table "guesses", force: :cascade do |t|
@@ -42,6 +55,27 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_17_192424) do
     t.string "url"
   end
 
+  create_table "sessions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "ip_address"
+    t.datetime "updated_at", null: false
+    t.string "user_agent"
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_sessions_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "email_address", null: false
+    t.string "password_digest", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email_address"], name: "index_users_on_email_address", unique: true
+  end
+
+  add_foreign_key "game_images", "games"
+  add_foreign_key "game_images", "images"
+  add_foreign_key "games", "users"
   add_foreign_key "guesses", "games"
   add_foreign_key "guesses", "images"
+  add_foreign_key "sessions", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_24_000004) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_27_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -65,6 +65,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_000004) do
   end
 
   create_table "users", force: :cascade do |t|
+    t.boolean "admin", default: false, null: false
     t.datetime "created_at", null: false
     t.string "email_address", null: false
     t.string "password_digest", null: false

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -2,47 +2,65 @@ require "test_helper"
 
 class GamesControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @game = games(:one)
+    @alice = users(:alice)
+    @bob = users(:bob)
+    @alice_game = games(:one)
+    @bob_game = games(:two)
   end
 
-  test "should get index" do
+  test "redirects unauthenticated user to login" do
+    get games_url
+    assert_redirected_to new_session_url
+  end
+
+  test "should get index when signed in" do
+    sign_in_as @alice
     get games_url
     assert_response :success
   end
 
-  test "should get new" do
+  test "should get new when signed in" do
+    sign_in_as @alice
     get new_game_url
     assert_response :success
   end
 
-  test "should create game" do
-    assert_difference("Game.count") do
-      post games_url, params: { game: { completed_at: @game.completed_at, score: @game.score, status: @game.status } }
+  test "should create game and materialize 5 game_images" do
+    sign_in_as @alice
+    assert_difference -> { Game.count } => 1, -> { GameImage.count } => 5 do
+      post games_url
     end
-
-    assert_redirected_to game_url(Game.last)
+    game = Game.last
+    assert_equal @alice, game.user
+    assert_equal (1..5).to_a, game.game_images.order(:position).pluck(:position)
+    assert_redirected_to game_url(game)
   end
 
-  test "should show game" do
-    get game_url(@game)
+  test "should show own game" do
+    sign_in_as @alice
+    get game_url(@alice_game)
     assert_response :success
   end
 
-  test "should get edit" do
-    get edit_game_url(@game)
-    assert_response :success
+  test "should not show another user's game" do
+    sign_in_as @alice
+    get game_url(@bob_game)
+    assert_response :not_found
   end
 
-  test "should update game" do
-    patch game_url(@game), params: { game: { completed_at: @game.completed_at, score: @game.score, status: @game.status } }
-    assert_redirected_to game_url(@game)
+  test "should not destroy another user's game" do
+    sign_in_as @alice
+    assert_no_difference("Game.count") do
+      delete game_url(@bob_game)
+    end
+    assert_response :not_found
   end
 
-  test "should destroy game" do
+  test "should destroy own game" do
+    sign_in_as @alice
     assert_difference("Game.count", -1) do
-      delete game_url(@game)
+      delete game_url(@alice_game)
     end
-
     assert_redirected_to games_url
   end
 end

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -3,9 +3,10 @@ require "test_helper"
 class GamesControllerTest < ActionDispatch::IntegrationTest
   setup do
     @alice = users(:alice)
-    @bob = users(:bob)
+    @bob   = users(:bob)
+    @admin = users(:admin)
     @alice_game = games(:one)
-    @bob_game = games(:two)
+    @bob_game   = games(:two)
   end
 
   test "redirects unauthenticated user to login" do
@@ -48,12 +49,18 @@ class GamesControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
-  test "should not destroy another user's game" do
+  test "non-admin cannot edit own game" do
     sign_in_as @alice
-    assert_no_difference("Game.count") do
-      delete game_url(@bob_game)
-    end
-    assert_response :not_found
+    get edit_game_url(@alice_game)
+    assert_redirected_to root_path
+  end
+
+  test "non-admin cannot update own game's score" do
+    sign_in_as @alice
+    original_score = @alice_game.score
+    patch game_url(@alice_game), params: { game: { score: 0 } }
+    assert_redirected_to root_path
+    assert_equal original_score, @alice_game.reload.score
   end
 
   test "should destroy own game" do
@@ -62,5 +69,20 @@ class GamesControllerTest < ActionDispatch::IntegrationTest
       delete game_url(@alice_game)
     end
     assert_redirected_to games_url
+  end
+
+  test "should not destroy another user's game" do
+    sign_in_as @alice
+    assert_no_difference("Game.count") do
+      delete game_url(@bob_game)
+    end
+    assert_response :not_found
+  end
+
+  test "admin can edit own game" do
+    sign_in_as @admin
+    admin_game = @admin.games.create!(status: "in_progress")
+    get edit_game_url(admin_game)
+    assert_response :success
   end
 end

--- a/test/controllers/guesses_controller_test.rb
+++ b/test/controllers/guesses_controller_test.rb
@@ -3,9 +3,10 @@ require "test_helper"
 class GuessesControllerTest < ActionDispatch::IntegrationTest
   setup do
     @alice = users(:alice)
-    @bob = users(:bob)
+    @bob   = users(:bob)
+    @admin = users(:admin)
     @alice_guess = guesses(:one)
-    @bob_guess = guesses(:two)
+    @bob_guess   = guesses(:two)
   end
 
   test "redirects unauthenticated user to login" do
@@ -39,5 +40,19 @@ class GuessesControllerTest < ActionDispatch::IntegrationTest
     sign_in_as @alice
     get guess_url(@bob_guess)
     assert_response :not_found
+  end
+
+  test "non-admin cannot edit own guess" do
+    sign_in_as @alice
+    get edit_guess_url(@alice_guess)
+    assert_redirected_to root_path
+  end
+
+  test "non-admin cannot destroy own guess" do
+    sign_in_as @alice
+    assert_no_difference("Guess.count") do
+      delete guess_url(@alice_guess)
+    end
+    assert_redirected_to root_path
   end
 end

--- a/test/controllers/guesses_controller_test.rb
+++ b/test/controllers/guesses_controller_test.rb
@@ -2,47 +2,42 @@ require "test_helper"
 
 class GuessesControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @guess = guesses(:one)
+    @alice = users(:alice)
+    @bob = users(:bob)
+    @alice_guess = guesses(:one)
+    @bob_guess = guesses(:two)
   end
 
-  test "should get index" do
+  test "redirects unauthenticated user to login" do
+    get guesses_url
+    assert_redirected_to new_session_url
+  end
+
+  test "index only shows own guesses" do
+    sign_in_as @alice
     get guesses_url
     assert_response :success
   end
 
-  test "should get new" do
-    get new_guess_url
-    assert_response :success
-  end
-
-  test "should create guess" do
+  test "should create guess on own game" do
+    sign_in_as @alice
     assert_difference("Guess.count") do
-      post guesses_url, params: { guess: { game_id: @guess.game_id, image_id: @guess.image_id, latitude: @guess.latitude, longitude: @guess.longitude } }
+      post guesses_url, params: { guess: { game_id: @alice_guess.game_id, image_id: @alice_guess.image_id, latitude: 1.0, longitude: 2.0 } }
     end
-
-    assert_redirected_to game_url(Guess.last.game)
+    assert_redirected_to game_url(@alice_guess.game)
   end
 
-  test "should show guess" do
-    get guess_url(@guess)
-    assert_response :success
-  end
-
-  test "should get edit" do
-    get edit_guess_url(@guess)
-    assert_response :success
-  end
-
-  test "should update guess" do
-    patch guess_url(@guess), params: { guess: { game_id: @guess.game_id, image_id: @guess.image_id, latitude: @guess.latitude, longitude: @guess.longitude } }
-    assert_redirected_to guess_url(@guess)
-  end
-
-  test "should destroy guess" do
-    assert_difference("Guess.count", -1) do
-      delete guess_url(@guess)
+  test "cannot create guess on another user's game" do
+    sign_in_as @alice
+    assert_no_difference("Guess.count") do
+      post guesses_url, params: { guess: { game_id: @bob_guess.game_id, image_id: @bob_guess.image_id, latitude: 1.0, longitude: 2.0 } }
     end
+    assert_response :not_found
+  end
 
-    assert_redirected_to guesses_url
+  test "cannot show another user's guess" do
+    sign_in_as @alice
+    get guess_url(@bob_guess)
+    assert_response :not_found
   end
 end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -3,7 +3,8 @@ require "test_helper"
 class ImagesControllerTest < ActionDispatch::IntegrationTest
   setup do
     @image = images(:one)
-    @user = users(:alice)
+    @user  = users(:alice)
+    @admin = users(:admin)
   end
 
   test "should get index without auth" do
@@ -16,44 +17,87 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "new image requires auth" do
-    get new_image_url
-    assert_redirected_to new_session_url
+  test "admin sees New/Edit/Destroy on index" do
+    sign_in_as @admin
+    get images_url
+    assert_select "a", text: "New image"
+    assert_select "a", text: "Edit"
   end
 
-  test "should get new when signed in" do
+  test "non-admin does not see New/Edit on index" do
     sign_in_as @user
+    get images_url
+    assert_select "a", text: "New image", count: 0
+    assert_select "a", text: "Edit", count: 0
+  end
+
+  test "non-admin cannot get new" do
+    sign_in_as @user
+    get new_image_url
+    assert_redirected_to root_path
+  end
+
+  test "non-admin cannot create" do
+    sign_in_as @user
+    assert_no_difference("Image.count") do
+      post images_url, params: { image: { latitude: @image.latitude, longitude: @image.longitude, title: @image.title, url: @image.url } }
+    end
+    assert_redirected_to root_path
+  end
+
+  test "non-admin cannot edit" do
+    sign_in_as @user
+    get edit_image_url(@image)
+    assert_redirected_to root_path
+  end
+
+  test "non-admin cannot update" do
+    sign_in_as @user
+    patch image_url(@image), params: { image: { title: "Hacked" } }
+    assert_redirected_to root_path
+    assert_not_equal "Hacked", @image.reload.title
+  end
+
+  test "non-admin cannot destroy" do
+    sign_in_as @user
+    assert_no_difference("Image.count") do
+      delete image_url(@image)
+    end
+    assert_redirected_to root_path
+  end
+
+  test "admin can get new" do
+    sign_in_as @admin
     get new_image_url
     assert_response :success
   end
 
-  test "should create image when signed in" do
-    sign_in_as @user
+  test "admin can create" do
+    sign_in_as @admin
     assert_difference("Image.count") do
-      post images_url, params: { image: { latitude: @image.latitude, longitude: @image.longitude, title: @image.title, url: @image.url } }
+      post images_url, params: { image: { latitude: @image.latitude, longitude: @image.longitude, title: @image.title, url: "https://example.com/new.jpg" } }
     end
-
     assert_redirected_to image_url(Image.last)
   end
 
-  test "should get edit when signed in" do
-    sign_in_as @user
+  test "admin can edit" do
+    sign_in_as @admin
     get edit_image_url(@image)
     assert_response :success
   end
 
-  test "should update image when signed in" do
-    sign_in_as @user
-    patch image_url(@image), params: { image: { latitude: @image.latitude, longitude: @image.longitude, title: @image.title, url: @image.url } }
+  test "admin can update" do
+    sign_in_as @admin
+    patch image_url(@image), params: { image: { latitude: @image.latitude, longitude: @image.longitude, title: "Renamed", url: @image.url } }
     assert_redirected_to image_url(@image)
+    assert_equal "Renamed", @image.reload.title
   end
 
-  test "should destroy image when signed in" do
-    sign_in_as @user
+  test "admin can destroy" do
+    sign_in_as @admin
     assert_difference("Image.count", -1) do
       delete image_url(@image)
     end
-
     assert_redirected_to images_url
   end
 end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -3,19 +3,32 @@ require "test_helper"
 class ImagesControllerTest < ActionDispatch::IntegrationTest
   setup do
     @image = images(:one)
+    @user = users(:alice)
   end
 
-  test "should get index" do
+  test "should get index without auth" do
     get images_url
     assert_response :success
   end
 
-  test "should get new" do
+  test "should show image without auth" do
+    get image_url(@image)
+    assert_response :success
+  end
+
+  test "new image requires auth" do
+    get new_image_url
+    assert_redirected_to new_session_url
+  end
+
+  test "should get new when signed in" do
+    sign_in_as @user
     get new_image_url
     assert_response :success
   end
 
-  test "should create image" do
+  test "should create image when signed in" do
+    sign_in_as @user
     assert_difference("Image.count") do
       post images_url, params: { image: { latitude: @image.latitude, longitude: @image.longitude, title: @image.title, url: @image.url } }
     end
@@ -23,22 +36,20 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to image_url(Image.last)
   end
 
-  test "should show image" do
-    get image_url(@image)
-    assert_response :success
-  end
-
-  test "should get edit" do
+  test "should get edit when signed in" do
+    sign_in_as @user
     get edit_image_url(@image)
     assert_response :success
   end
 
-  test "should update image" do
+  test "should update image when signed in" do
+    sign_in_as @user
     patch image_url(@image), params: { image: { latitude: @image.latitude, longitude: @image.longitude, title: @image.title, url: @image.url } }
     assert_redirected_to image_url(@image)
   end
 
-  test "should destroy image" do
+  test "should destroy image when signed in" do
+    sign_in_as @user
     assert_difference("Image.count", -1) do
       delete image_url(@image)
     end

--- a/test/fixtures/game_images.yml
+++ b/test/fixtures/game_images.yml
@@ -1,0 +1,29 @@
+alice_round1:
+  game: one
+  image: one
+  position: 1
+
+alice_round2:
+  game: one
+  image: two
+  position: 2
+
+alice_round3:
+  game: one
+  image: three
+  position: 3
+
+alice_round4:
+  game: one
+  image: four
+  position: 4
+
+alice_round5:
+  game: one
+  image: five
+  position: 5
+
+bob_round1:
+  game: two
+  image: one
+  position: 1

--- a/test/fixtures/games.yml
+++ b/test/fixtures/games.yml
@@ -1,11 +1,13 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
+  user: alice
   status: MyString
   score: 1
   completed_at: 2026-04-17 14:24:20
 
 two:
+  user: bob
   status: MyString
   score: 1
   completed_at: 2026-04-17 14:24:20

--- a/test/fixtures/images.yml
+++ b/test/fixtures/images.yml
@@ -11,3 +11,21 @@ two:
   latitude: 9.99
   longitude: 9.99
   title: Test Valley
+
+three:
+  url: https://example.com/forest.jpg
+  latitude: 9.99
+  longitude: 9.99
+  title: Test Forest
+
+four:
+  url: https://example.com/desert.jpg
+  latitude: 9.99
+  longitude: 9.99
+  title: Test Desert
+
+five:
+  url: https://example.com/lake.jpg
+  latitude: 9.99
+  longitude: 9.99
+  title: Test Lake

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -5,3 +5,8 @@ alice:
 bob:
   email_address: bob@example.com
   password_digest: <%= BCrypt::Password.create("password123") %>
+
+admin:
+  email_address: admin@example.com
+  password_digest: <%= BCrypt::Password.create("password123") %>
+  admin: true

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,7 @@
+alice:
+  email_address: alice@example.com
+  password_digest: <%= BCrypt::Password.create("password123") %>
+
+bob:
+  email_address: bob@example.com
+  password_digest: <%= BCrypt::Password.create("password123") %>

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -17,9 +17,13 @@ class GameTest < ActiveSupport::TestCase
   end
 
   test "new game can be created with in_progress status" do
-    game = Game.create!(status: "in_progress")
+    game = users(:alice).games.create!(status: "in_progress")
     assert_equal "in_progress", game.status
     assert_nil game.score
     assert_nil game.completed_at
+  end
+
+  test "belongs to a user" do
+    assert_equal :belongs_to, Game.reflect_on_association(:user).macro
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,3 +13,9 @@ module ActiveSupport
     # Add more helper methods to be used by all tests here...
   end
 end
+
+class ActionDispatch::IntegrationTest
+  def sign_in_as(user, password = "password123")
+    post session_url, params: { email_address: user.email_address, password: password }
+  end
+end


### PR DESCRIPTION
## Summary

Adds user accounts (Phase 1), per-game image sets (Phase 2), and an admin role with mutation lockdown across `/images`, `/games`, and `/guesses`. Implements the Milestone 1 auth rubric: scoped access, no leaked credentials, working logout with flash.

## What's new

**Auth (Phase 1)** — built on Rails 8's `bin/rails generate authentication`.
- `User` (email + `has_secure_password`), `Session`, `Current` concern
- Routes: `/session/new`, `/registration/new`, `/passwords/:token`
- Sign-in/up/out nav, global flash banner in layout
- Email normalized on save; password ≥ 8 chars
- Email enumeration mitigated: failed login says "Try another email address or password"; signup uniqueness error masked as "is invalid"

**Per-game image sets (Phase 2)** — `game_images` join table.
- `Game` materializes 5 `GameImage` rows in a transaction at create-time
- `Game#show` reads image at `position: round`; ordering is stable across reloads
- All game/guess/image controllers scoped through `Current.user.games` — non-owner access returns 404

**Admin role + mutation lockdown** — `admin:boolean` on User.
- Image library mutations (`new/create/edit/update/destroy`) admin-only; reads stay open
- Guess mutations admin-only — except `create`, which is gameplay
- Game `edit/update` admin-only — `score`, `status`, `completed_at` can only be written by the backend (results action). Users can still destroy their own games.
- Mutation links hidden from non-admin views
- No default admin seed (public repo) — promote via Rails console: `User.find_by(email_address: "you@x").update(admin: true)`
- `admin?` helper resumes session lazily so it works correctly on pages with `allow_unauthenticated_access` (otherwise `Current.user` is `nil` there)

**Other**
- README updated (Data model, new "Conventions" section covering auth scoping, admin role, Turbo + inline scripts)
- 45 tests passing, rubocop clean

## Heads up: destructive migration

`20260424000003_add_user_to_games.rb` deletes existing guesses and games before adding the NOT NULL `user_id` FK. Existing prod games will be wiped — re-seed after deploy.

## Heads up: nav already added

Issue #14 (navigation bar) overlaps with this PR — basic nav is in place. That task should be rescoped to styling, or closed.

## Test plan

- [ ] Sign up → land on home, signed in
- [ ] Sign out → redirect to sign-in, flash shows
- [ ] Bad password → no leak about whether email exists
- [ ] Direct URL to another user's `/games/:id` → 404
- [ ] Play a game → 5 images, scores recorded, results page works
- [ ] As non-admin, `/images/new` and `/games/:id/edit` redirect to root with "Admin access required."
- [ ] As non-admin, "Destroy" button still appears on own games (delete works); no Edit button
- [ ] Promote yourself to admin via console → "New image" / "Edit" / "Destroy" buttons appear on `/images`
- [ ] `bin/rails test` green, `bin/rubocop` clean
