### PR TITLE
dev: default Active Storage to local disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ To manage the image library or edit past guesses through the UI, you need an adm
 
 ### S3 / Active Storage setup (for user uploads)
 
-User-uploaded images go through Active Storage's direct-upload flow to S3 (the browser PUTs the original file straight to S3, then a background job converts it). To enable in development, set:
+User-uploaded images go through Active Storage's direct-upload flow. Development defaults to local disk (`storage/`) — no AWS setup required. Production uses S3.
+
+To exercise the S3 path locally (parity testing), flip `config.active_storage.service` to `:amazon` in `config/environments/development.rb` and export:
 
 ```bash
 export AWS_ACCESS_KEY_ID=...
@@ -75,8 +77,6 @@ export AWS_SECRET_ACCESS_KEY=...
 export S3_BUCKET=landscape-guessr-dev
 export AWS_REGION=us-east-2
 ```
-
-If you don't want to use S3 locally, edit `config/environments/development.rb` and change `config.active_storage.service` to `:local`. Bulk uploads will then write to `storage/`. (Production always uses S3 — see `config/storage.yml`.)
 
 ## Data model
 

--- a/app/jobs/process_image_job.rb
+++ b/app/jobs/process_image_job.rb
@@ -26,10 +26,13 @@ class ProcessImageJob < ApplicationJob
       end
 
       processed = Image.process_path(file.path, blob.filename.to_s)
-      image.photo.attach(processed)
-      image.photo.blob.update!(
-        metadata: image.photo.blob.metadata.merge("processed" => true)
-      )
+      # Stamp "processed" at blob-creation time, not after, so it lives in
+      # the same INSERT as the row itself. The auto-enqueued AnalyzeJob
+      # then deserializes the blob *after* commit, reads metadata with
+      # "processed" already present, and merges its own keys on top —
+      # closing the race where AnalyzeJob's update! could clobber a
+      # post-attach metadata write.
+      image.photo.attach(processed.merge(metadata: { "processed" => true }))
     end
 
     # Backfill ImageSetItem coords from the image's newly-extracted GPS so

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,9 +28,9 @@ Rails.application.configure do
   # Change to :null_store to avoid any caching.
   config.cache_store = :memory_store
 
-  # Store uploaded files on S3 in dev too, so we exercise the same path as
-  # production. Flip this back to :local if you want to work offline.
-  config.active_storage.service = :amazon
+  # Store uploaded files on local disk in dev. Flip to :amazon to exercise
+  # the same S3 path as production (requires AWS_ACCESS_KEY_ID/SECRET).
+  config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
## Summary
1. **Default Active Storage to local disk in dev.** Avoids writing local-dev uploads to the prod S3 bucket and removes the need for AWS creds to run `bin/dev`. Production unchanged. Flip back to `:amazon` in `config/environments/development.rb` to exercise the S3 path.

2. **Fix race in `ProcessImageJob`.** The job was stamping `blob.metadata["processed"] = true` via a second `update!` after `attach`. That left a window where the auto-enqueued `ActiveStorage::AnalyzeJob` could deserialize the blob mid-stream and write metadata back without `processed`, stranding the image on "Processing..." forever. Fixed by setting `metadata: { "processed" => true }` at blob-creation time so it lives in the same INSERT as the row. AnalyzeJob then reads the post-commit metadata and merges its own keys on top, preserving the flag in every interleaving.

## Test plan
- [ ] `bin/dev` boots without AWS env vars; uploads land under `storage/`
- [ ] Bulk-upload a small batch and confirm every image's `metadata["processed"] == true` after the dust settles (no stuck "Processing..." badges)
- [ ] Production env config untouched (`config/environments/production.rb` still `:amazon`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)