### PR TITLE
Enhance accessibility based on Skynet report

### DIFF
--- a/app/views/games/results.html.erb
+++ b/app/views/games/results.html.erb
@@ -59,7 +59,7 @@
            class="rounded-lg border border-gray-200 hover:border-blue-300 transition cursor-pointer px-4 py-3 flex flex-col sm:flex-row sm:items-center gap-3">
         <% thumb = image_src(row[:guess].image, width: 200) %>
         <% if thumb %>
-          <img src="<%= thumb %>" alt="<%= row[:guess].image.title %>"
+          <img src="<%= thumb %>" alt="<%= row[:guess].image.title.presence || 'Landscape image' %>"
                loading="lazy"
                class="shrink-0 w-full sm:w-24 h-20 sm:h-16 object-cover rounded-md border border-gray-100">
         <% end %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -63,6 +63,7 @@
                     data-zoomable-target="originalButton"
                     data-action="zoomable#loadOriginal"
                     data-zoomable-url-param="<%= image_src(@image) %>"
+                    aria-label="Load full quality version of the current image"
                     class="hidden text-gray-500 hover:text-blue-600 underline-offset-2 hover:underline cursor-pointer">
               load full quality
             </button>

--- a/app/views/image_sets/locations.html.erb
+++ b/app/views/image_sets/locations.html.erb
@@ -136,7 +136,7 @@
             <%# Thumbnail (or a "processing" placeholder while ProcessImageJob
                 converts the freshly-uploaded HEIC) %>
             <% if item.image.processed? %>
-              <img src="<%= image_src(item.image, width: 200) %>" alt="<%= item.title %>"
+              <img src="<%= image_src(item.image, width: 200) %>" alt="<%= item.title.presence || 'Landscape image' %>"
                    loading="lazy" decoding="async"
                    class="w-full sm:w-24 h-20 sm:h-16 object-cover rounded-md border border-gray-100 shrink-0">
             <% else %>

--- a/app/views/image_sets/show.html.erb
+++ b/app/views/image_sets/show.html.erb
@@ -45,7 +45,7 @@
       <% @items.each do |item| %>
         <%= link_to item.image,
               class: "block rounded-md overflow-hidden border border-gray-200 hover:border-blue-300 transition" do %>
-          <img src="<%= image_src(item.image, width: 400) %>" alt="<%= item.title %>"
+          <img src="<%= image_src(item.image, width: 400) %>" alt="<%= item.title.presence || 'Landscape image' %>"
                loading="lazy" decoding="async"
                class="w-full h-32 object-cover">
           <div class="px-2 py-1.5 bg-white">

--- a/app/views/images/_image.html.erb
+++ b/app/views/images/_image.html.erb
@@ -2,7 +2,7 @@
     anywhere on the card to dive into the image's detail page. %>
 <%= link_to image, id: dom_id(image),
       class: "block rounded-md overflow-hidden border border-gray-200 hover:border-blue-300 transition" do %>
-  <img src="<%= image_src(image, width: 400) %>" alt="<%= image.title %>"
+  <img src="<%= image_src(image, width: 400) %>" alt="<%= image.title.presence || 'Landscape image' %>"
        loading="lazy" decoding="async"
        class="w-full h-32 object-cover">
   <div class="px-2 py-1.5 bg-white">

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -32,7 +32,7 @@
          class="lg:col-span-2 space-y-1">
       <div data-zoomable-target="viewport"
            class="h-[60vh] flex items-center justify-center bg-gray-100 rounded-md border border-gray-200 select-none">
-        <img src="<%= image_src(@image, width: Image::ZOOM_CAP_WIDTH) %>" alt="<%= @image.title %>"
+        <img src="<%= image_src(@image, width: Image::ZOOM_CAP_WIDTH) %>" alt="<%= @image.title.presence || 'Landscape image' %>"
              class="max-w-full max-h-full object-contain">
       </div>
       <div class="flex items-center justify-between gap-2 text-xs text-gray-500">
@@ -42,6 +42,7 @@
                   data-zoomable-target="originalButton"
                   data-action="zoomable#loadOriginal"
                   data-zoomable-url-param="<%= image_src(@image) %>"
+                  aria-label="Load full quality version of the current image"
                   class="hidden text-gray-500 hover:text-blue-600 underline-offset-2 hover:underline cursor-pointer">
             load full quality
           </button>
@@ -57,6 +58,7 @@
           doesn't show. %>
       <% if (gmap = @image.google_maps_url) %>
         <%= link_to "Open in Google Maps ↗", gmap, target: "_blank", rel: "noopener",
+              aria: { label: "Open in Google Maps (opens in a new tab)" },
               class: "btn-secondary w-full text-center" %>
       <% end %>
 
@@ -69,6 +71,7 @@
         <div class="text-xs">
           <p class="text-gray-500 mb-0.5">Source</p>
           <%= link_to @image.url, @image.url, target: "_blank", rel: "noopener",
+                aria: { label: "Source URL (opens in a new tab)" },
                 class: "text-blue-600 hover:underline break-all" %>
         </div>
       <% end %>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "Update Password" %>
+
 <div class="mx-auto md:w-2/3 w-full">
   <h1 class="heading-page">Update your password</h1>
 

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "Forgot Password" %>
+
 <div class="mx-auto md:w-2/3 w-full">
   <h1 class="heading-page">Forgot your password?</h1>
 

--- a/app/views/practice/show.html.erb
+++ b/app/views/practice/show.html.erb
@@ -37,6 +37,7 @@
                   data-zoomable-target="originalButton"
                   data-action="zoomable#loadOriginal"
                   data-zoomable-url-param="<%= image_src(@image) %>"
+                  aria-label="Load full quality version of the current image"
                   class="hidden text-gray-500 hover:text-blue-600 underline-offset-2 hover:underline cursor-pointer">
             load full quality
           </button>
@@ -67,6 +68,7 @@
 
     <%= link_to "View image details", @image,
           target: "_blank",
+          aria: { label: "View image details (opens in a new tab)" },
           data: { practice_target: "imageLink" },
           class: "hidden text-blue-600 hover:underline font-medium" %>
   </div>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "Sign up" %>
+
 <div class="mx-auto md:w-2/3 w-full">
   <h1 class="heading-page">Sign up</h1>
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "Sign in" %>
+
 <div class="mx-auto md:w-2/3 w-full">
   <h1 class="heading-page">Sign in</h1>
 

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,14 +1,14 @@
 {
   "ignored_warnings": [
     {
-      "fingerprint": "67595a857f4c66e5863d9db8569c249f719e6696d66431381d7094defd491b87",
-      "note": "google_maps_url builds an https URL from numeric lat/lng (decimal columns). The URL string is structurally safe — only digits and a comma can land in it."
+      "fingerprint": "e0fe94cce07a9e720e3803c8e50d12f541fb68189cb8276bb212e9eb27d050a2",
+      "note": "google_maps_url builds an https URL from numeric lat/lng (decimal columns). The URL string is structurally safe — only digits and a comma can land in it. The show view receives @image from the database via the show action, never from user-submitted image_params."
     },
     {
-      "fingerprint": "c142c51e3bf52d8f8a1c1652932061ae01c8a0ce9aadde6f87d76f507e7d21af",
-      "note": "Image#url is admin-only-editable; the view also gates on an http(s):// scheme regex before rendering the link, so a javascript: URL can't reach link_to even from a compromised admin or corrupted seed."
+      "fingerprint": "9fe716f316f224bbb0976f48144e5f31e3e4233575f00fa68d3fec6b219f0adc",
+      "note": "Image#url is admin-only-editable; the view also gates on an http(s):// scheme regex before rendering the link, so a javascript: URL can't reach link_to even from a compromised admin or corrupted seed. The show view receives @image from the database, never from user-submitted image_params."
     }
   ],
-  "updated": "2026-05-08",
+  "updated": "2026-05-12",
   "brakeman_version": "8.0.4"
 }


### PR DESCRIPTION
- Added aria-labels to 'target=_blank' links to warn screen readers
- Added descriptive fallbacks for dynamic image alt text
- Provided explicit aria-labels for context-dependent action buttons
- Added semantic content_for(:title) definitions to Devise auth views