### PR TITLE
feat(auth): Google sign-in, email verification, account deletion

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,9 +47,18 @@ gem "image_processing", "~> 1.2"
 # Read EXIF metadata (used to auto-fill GPS coords from uploaded photos)
 gem "exifr", "~> 1.4"
 
+# OAuth sign-in (Google)
+gem "omniauth"
+gem "omniauth-google-oauth2"
+gem "omniauth-rails_csrf_protection"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
+
+  # Loads .env files into ENV in dev/test so secrets (Google OAuth, AWS) don't
+  # need to be exported per-shell. Production reads ENV directly (Heroku config).
+  gem "dotenv-rails"
 
   # Audits gems for known security defects (use config/bundler-audit.yml to ignore issues)
   gem "bundler-audit", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,11 +127,20 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     dotenv (3.2.0)
+    dotenv-rails (3.2.0)
+      dotenv (= 3.2.0)
+      railties (>= 6.1)
     drb (2.2.3)
     ed25519 (1.4.0)
     erb (6.0.3)
     erubi (1.13.1)
     exifr (1.5.1)
+    faraday (2.14.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-aarch64-linux-musl)
     ffi (1.17.4-arm-linux-gnu)
@@ -142,6 +151,8 @@ GEM
     ffi (1.17.4-x86_64-linux-musl)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    hashie (5.1.0)
+      logger
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     image_processing (1.14.0)
@@ -162,6 +173,8 @@ GEM
       activesupport (>= 7.0.0)
     jmespath (1.6.2)
     json (2.19.3)
+    jwt (3.1.2)
+      base64
     kamal (2.11.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -194,6 +207,10 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
+    multi_xml (0.9.1)
+      bigdecimal (>= 3.1, < 5)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-imap (0.6.3)
       date
       net-protocol
@@ -225,6 +242,30 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.2-x86_64-linux-musl)
       racc (~> 1.4)
+    oauth2 (2.0.18)
+      faraday (>= 0.17.3, < 4.0)
+      jwt (>= 1.0, < 4.0)
+      logger (~> 1.2)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0, >= 2.0.3)
+      version_gem (~> 1.1, >= 1.1.9)
+    omniauth (2.1.4)
+      hashie (>= 3.4.6)
+      logger
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-google-oauth2 (1.2.2)
+      jwt (>= 2.9.2)
+      oauth2 (~> 2.0)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8)
+    omniauth-oauth2 (1.9.0)
+      oauth2 (>= 2.0.2, < 3)
+      omniauth (~> 2.0)
+    omniauth-rails_csrf_protection (2.0.1)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     ostruct (0.6.3)
     parallel (2.0.1)
     parser (3.3.11.1)
@@ -253,6 +294,10 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
+    rack-protection (4.2.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
     rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -340,6 +385,9 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    snaky_hash (2.0.3)
+      hashie (>= 0.1.0, < 6)
+      version_gem (>= 1.1.8, < 3)
     sshkit (1.25.0)
       base64
       logger
@@ -379,6 +427,7 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
+    version_gem (1.1.9)
     web-console (4.3.0)
       actionview (>= 8.0.0)
       bindex (>= 0.4.0)
@@ -412,11 +461,15 @@ DEPENDENCIES
   bundler-audit
   capybara
   debug
+  dotenv-rails
   exifr (~> 1.4)
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
   kamal
+  omniauth
+  omniauth-google-oauth2
+  omniauth-rails_csrf_protection
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)
@@ -467,11 +520,14 @@ CHECKSUMS
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d
+  dotenv-rails (3.2.0) sha256=657e25554ba622ffc95d8c4f1670286510f47f2edda9f68293c3f661b303beab
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   ed25519 (1.4.0) sha256=16e97f5198689a154247169f3453ef4cfd3f7a47481fde0ae33206cdfdcac506
   erb (6.0.3) sha256=e43685a8a0a0ea6a924871b2162e8953ef73147ce46b75b36d1f6774fd286e91
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   exifr (1.5.1) sha256=ad87a5dbc92946fbf1d8ccd178d557d95d9168e8b3c5c5f381ea2bffcc312521
+  faraday (2.14.1) sha256=a43cceedc1e39d188f4d2cdd360a8aaa6a11da0c407052e426ba8d3fb42ef61c
+  faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
   ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
   ffi (1.17.4-aarch64-linux-musl) sha256=9286b7a615f2676245283aef0a0a3b475ae3aae2bb5448baace630bb77b91f39
   ffi (1.17.4-arm-linux-gnu) sha256=d6dbddf7cb77bf955411af5f187a65b8cd378cb003c15c05697f5feee1cb1564
@@ -481,6 +537,7 @@ CHECKSUMS
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
   ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
+  hashie (5.1.0) sha256=c266471896f323c446ea8207f8ffac985d2718df0a0ba98651a3057096ca3870
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   image_processing (1.14.0) sha256=754cc169c9c262980889bec6bfd325ed1dafad34f85242b5a07b60af004742fb
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
@@ -489,6 +546,7 @@ CHECKSUMS
   jbuilder (2.14.1) sha256=4eb26376ff60ef100cb4fd6fd7533cd271f9998327e86adf20fd8c0e69fabb42
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
   json (2.19.3) sha256=289b0bb53052a1fa8c34ab33cc750b659ba14a5c45f3fcf4b18762dc67c78646
+  jwt (3.1.2) sha256=af6991f19a6bb4060d618d9add7a66f0eeb005ac0bc017cd01f63b42e122d535
   kamal (2.11.0) sha256=1408864425e0dec7e0a14d712a3b13f614e9f3a425b7661d3f9d287a51d7dd75
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
@@ -501,6 +559,8 @@ CHECKSUMS
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.4) sha256=df1304664589d40f46089247fdc451f866b0ce0d7cae1457a15fc1eb7d48dca1
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
+  multi_xml (0.9.1) sha256=7ce766b59c17241ed62976caeae1fae9b2431b263398c35396239a68c4a64e57
+  net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   net-imap (0.6.3) sha256=9bab75f876596d09ee7bf911a291da478e0cd6badc54dfb82874855ccc82f2ad
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
@@ -517,6 +577,11 @@ CHECKSUMS
   nokogiri (1.19.2-x64-mingw-ucrt) sha256=8ccf25eea3363a2c7b3f2e173a3400582c633cfead27f805df9a9c56d4852d1a
   nokogiri (1.19.2-x86_64-linux-gnu) sha256=fa8feca882b73e871a9845f3817a72e9734c8e974bdc4fbad6e4bc6e8076b94f
   nokogiri (1.19.2-x86_64-linux-musl) sha256=93128448e61a9383a30baef041bf1f5817e22f297a1d400521e90294445069a8
+  oauth2 (2.0.18) sha256=bacf11e470dfb963f17348666d0a75c7b29ca65bc48fd47be9057cf91a403287
+  omniauth (2.1.4) sha256=42a05b0496f0d22e1dd85d42aaf602f064e36bb47a6826a27ab55e5ba608763c
+  omniauth-google-oauth2 (1.2.2) sha256=74c3f3d0221c048f938846092fb15a1f15237526f50a7c93d9793f9a4ff1be11
+  omniauth-oauth2 (1.9.0) sha256=ed15f6d9d20991807ce114cc5b9c1453bce3645b64e51c68c90cff5ff153fee8
+  omniauth-rails_csrf_protection (2.0.1) sha256=c6e3204d7e3925bb537cb52d50fdfc9f05293f1a9d87c5d4ab4ca3a39ba8c32d
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
   parallel (2.0.1) sha256=337782d3e39f4121e67563bf91dd8ece67f48923d90698614773a0ec9a5b2c7d
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
@@ -536,6 +601,7 @@ CHECKSUMS
   puma (8.0.0) sha256=1681050b8b60fab1d3033255ab58b6aec64cd063e43fc6f8204bcb8bf9364b88
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
+  rack-protection (4.2.1) sha256=cf6e2842df8c55f5e4d1a4be015e603e19e9bc3a7178bae58949ccbb58558bac
   rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
@@ -559,6 +625,7 @@ CHECKSUMS
   rubyzip (3.2.2) sha256=c0ed99385f0625415c8f05bcae33fe649ed2952894a95ff8b08f26ca57ea5b3c
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   selenium-webdriver (4.43.0) sha256=a634377b964b701c6ac0a009ce3a08fa34ec1e1e7fe9a6d57e3088d14529a65c
+  snaky_hash (2.0.3) sha256=25a3d299566e8153fb02fa23fd9a9358845950f7a523ddbbe1fa1e0d79a6d456
   sshkit (1.25.0) sha256=c8c6543cdb60f91f1d277306d585dd11b6a064cb44eab0972827e4311ff96744
   stimulus-rails (1.3.4) sha256=765676ffa1f33af64ce026d26b48e8ffb2e0b94e0f50e9119e11d6107d67cb06
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
@@ -584,6 +651,7 @@ CHECKSUMS
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
+  version_gem (1.1.9) sha256=0c1a0962ae543c84a00889bb018d9f14d8f8af6029d26b295d98774e3d2eb9a4
   web-console (4.3.0) sha256=e13b71301cdfc2093f155b5aa3a622db80b4672d1f2f713119cc7ec7ac6a6da4
   websocket (1.2.11) sha256=b7e7a74e2410b5e85c25858b26b3322f29161e300935f70a0e0d3c35e0462737
   websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The `Image.visible_to(user)` scope (in `app/models/image.rb`) is the canonical w
 | `/registration/new`, `/session/new`, `/passwords/new` | Sign up, sign in, password reset |
 | `/auth/google_oauth2`, `/auth/google_oauth2/callback` | OAuth sign-in entry + callback |
 | `/profile/setup_username` | Where OAuth-created users pick a username before they can do anything else |
-| `/profile` | Current user's profile |
+| `/profile` | Current user's profile (also exposes account deletion — `DELETE /profile`) |
 | `/games` | Paginated list of your games (filter by status, sort by date or score) |
 | `/games/:id` | Play the next round of an in-progress game |
 | `/games/:id/results` | Per-round breakdown + summary map after game finishes |

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ In development, seeds also create three demo accounts so the leaderboard isn't e
 
 To manage the image library or edit past guesses through the UI, you need an admin account. Sign up normally, then promote yourself via `bin/rails c`: `User.find_by(email_address: "you@x").update(admin: true)`. On Heroku: `heroku run rails console`.
 
+### Google sign-in (optional)
+
+Set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` in `.env` (loaded by `dotenv-rails` in dev). Get them from Google Cloud Console → Google Auth Platform → Clients → Web application; add `http://localhost:3000/auth/google_oauth2/callback` as an authorized redirect URI. Without them, the "Sign in with Google" button errors but password sign-in still works.
+
 ### S3 / Active Storage setup (for user uploads)
 
 User-uploaded images go through Active Storage's direct-upload flow. Development defaults to local disk (`storage/`) — no AWS setup required. Production uses S3.
@@ -82,8 +86,9 @@ export AWS_REGION=us-east-2
 
 | Model | Belongs to | Has many | Key columns |
 |---|---|---|---|
-| `User` | — | `sessions`, `games`, `image_sets` | `email_address`, `username`, `password_digest`, `admin` |
+| `User` | — | `sessions`, `games`, `image_sets`, `connected_services` | `email_address`, `username` (nullable while OAuth users pick one), `password_digest`, `admin` |
 | `Session` | `User` | — | `ip_address`, `user_agent` |
+| `ConnectedService` | `User` | — | `provider`, `uid`, `email` (unique on `[provider, uid]`; maps OAuth identities to users) |
 | `Game` | `User`, `ImageSet?` | `game_images`, `guesses`, `images` (through `game_images`) | `status`, `score`, `completed_at` |
 | `GameImage` | `Game`, `Image` | — | `position` (1–5), `answer_latitude`, `answer_longitude` (snapshot at game-creation time) |
 | `Image` | — | `guesses`, `game_images`, `image_set_items`, `image_sets` (through items) | `url`, `latitude`, `longitude`, `title`; optional `photo` Active Storage attachment |
@@ -105,6 +110,8 @@ The `Image.visible_to(user)` scope (in `app/models/image.rb`) is the canonical w
 |---|---|
 | `/` | Landing page; primary CTA = "Start new game" on the system-default set |
 | `/registration/new`, `/session/new`, `/passwords/new` | Sign up, sign in, password reset |
+| `/auth/google_oauth2`, `/auth/google_oauth2/callback` | OAuth sign-in entry + callback |
+| `/profile/setup_username` | Where OAuth-created users pick a username before they can do anything else |
 | `/profile` | Current user's profile |
 | `/games` | Paginated list of your games (filter by status, sort by date or score) |
 | `/games/:id` | Play the next round of an in-progress game |
@@ -148,6 +155,7 @@ heroku addons:create heroku-postgresql:essential-0
 heroku buildpacks:add --index 1 heroku-community/apt   # pulls libvips42 via Aptfile
 heroku buildpacks:add heroku/ruby
 heroku config:set AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... S3_BUCKET=... AWS_REGION=...
+heroku config:set GOOGLE_CLIENT_ID=... GOOGLE_CLIENT_SECRET=...   # required for Sign in with Google in prod
 heroku config:set MALLOC_ARENA_MAX=2 ACTIVE_JOB_ASYNC_MAX_THREADS=1   # caps glibc heap fragmentation + concurrent libvips decodes; needed on 512MB dynos
 git push heroku main:main
 heroku run rails db:migrate db:seed

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,8 @@ class ApplicationController < ActionController::Base
   # flash so the user lands on a real page.
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
+  before_action :require_username_set
+
   helper_method :admin?
 
   PER_PAGE_OPTIONS = [ 25, 50, 100, 250, 500 ].freeze
@@ -23,6 +25,15 @@ class ApplicationController < ActionController::Base
 
     def require_admin
       redirect_to root_path, alert: "Admin access required." unless admin?
+    end
+
+    # OAuth-created users start with a blank username; force them to pick one
+    # before they can do anything else. Skipped on the setup page itself, on
+    # sign-out, and on the OAuth callback (where the redirect is set up).
+    def require_username_set
+      return unless authenticated?
+      return if Current.user.username.present?
+      redirect_to setup_username_profile_path
     end
 
     def render_not_found

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,8 +13,9 @@ class ApplicationController < ActionController::Base
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
   before_action :require_username_set
+  before_action :require_email_verified
 
-  helper_method :admin?
+  helper_method :admin?, :email_verified?
 
   PER_PAGE_OPTIONS = [ 25, 50, 100, 250, 500 ].freeze
 
@@ -25,6 +26,17 @@ class ApplicationController < ActionController::Base
 
     def require_admin
       redirect_to root_path, alert: "Admin access required." unless admin?
+    end
+
+    def email_verified?
+      authenticated? && Current.user.email_verified?
+    end
+
+    def require_email_verified
+      return unless authenticated?
+      return if Current.user.email_verified?
+      flash[:verify_email] = true
+      redirect_to root_path
     end
 
     # OAuth-created users start with a blank username; force them to pick one

--- a/app/controllers/email_verifications_controller.rb
+++ b/app/controllers/email_verifications_controller.rb
@@ -1,0 +1,24 @@
+class EmailVerificationsController < ApplicationController
+  allow_unauthenticated_access only: :show
+  skip_before_action :require_email_verified
+
+  def show
+    user = User.find_by_email_verification_token(params[:token])
+
+    if user
+      user.update!(email_verified_at: Time.current)
+      redirect_to root_path, notice: "Email verified successfully!"
+    else
+      redirect_to root_path, alert: "Verification link is invalid or has expired."
+    end
+  end
+
+  def create
+    if Current.user.email_verified?
+      redirect_to root_path, notice: "Your email is already verified."
+    else
+      EmailVerificationMailer.verify(Current.user).deliver_later
+      redirect_to root_path, notice: "Verification email sent. Check your inbox."
+    end
+  end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,6 @@
 class HomeController < ApplicationController
   allow_unauthenticated_access only: %i[ start ]
+  skip_before_action :require_email_verified
 
   def start
     @default_set = ImageSet.default if authenticated?

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,5 +1,6 @@
 class ImagesController < ApplicationController
   allow_unauthenticated_access only: %i[ index show map ]
+  skip_before_action :require_email_verified, only: %i[ index show map ]
   before_action :require_admin,    only: %i[ new create destroy ]
   before_action :set_image,        only: %i[ show edit update destroy ]
   before_action :require_editable, only: %i[ edit update ]

--- a/app/controllers/practice_controller.rb
+++ b/app/controllers/practice_controller.rb
@@ -1,5 +1,6 @@
 class PracticeController < ApplicationController
   allow_unauthenticated_access only: %i[ show check ]
+  skip_before_action :require_email_verified
 
   def show
     default_set = ImageSet.default

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,5 +1,6 @@
 class ProfilesController < ApplicationController
   skip_before_action :require_username_set, only: %i[ setup_username update_username ]
+  skip_before_action :require_email_verified
 
   def show
     @user = Current.user

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,4 +1,6 @@
 class ProfilesController < ApplicationController
+  skip_before_action :require_username_set, only: %i[ setup_username update_username ]
+
   def show
     @user = Current.user
     completed = @user.games.where.not(completed_at: nil)
@@ -6,4 +8,25 @@ class ProfilesController < ApplicationController
     @best_score   = completed.maximum(:score)
     @avg_score    = completed.average(:score)&.round
   end
+
+  def setup_username
+    redirect_to(profile_path) and return if Current.user.username.present?
+    @user = Current.user
+  end
+
+  def update_username
+    redirect_to(profile_path) and return if Current.user.username.present?
+    @user = Current.user
+    if @user.update(username_params)
+      redirect_to after_authentication_url, notice: "Username saved."
+    else
+      flash.now[:alert] = @user.errors.full_messages.first
+      render :setup_username, status: :unprocessable_entity
+    end
+  end
+
+  private
+    def username_params
+      params.expect(user: [ :username ])
+    end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,5 +1,5 @@
 class ProfilesController < ApplicationController
-  skip_before_action :require_username_set, only: %i[ setup_username update_username ]
+  skip_before_action :require_username_set, only: %i[ setup_username update_username destroy ]
   skip_before_action :require_email_verified
 
   def show
@@ -24,6 +24,44 @@ class ProfilesController < ApplicationController
       flash.now[:alert] = @user.errors.full_messages.first
       render :setup_username, status: :unprocessable_entity
     end
+  end
+
+  # Permanently delete the current user's account and everything they own.
+  # Sessions, games (and their guesses), image sets, and connected services
+  # cascade via dependent: :destroy. ImageSet#sweep_orphan_images cleans up
+  # the underlying Images (and S3 blobs) for items that were only in this
+  # user's sets; images shared with other users' sets or the system-default
+  # set are preserved. Other users' games on this user's (now-deleted)
+  # public set survive with image_set_id = nil via ImageSet's
+  # dependent: :nullify on :games.
+  def destroy
+    user = Current.user
+
+    typed_email = params[:confirm_email].to_s.strip.downcase
+    if typed_email != user.email_address.to_s.downcase
+      redirect_to profile_path, alert: "Type your email address to confirm deletion."
+      return
+    end
+
+    # OAuth-linked users have an auto-generated password they never see
+    # (see Sessions::OmniAuthsController#build_oauth_user), so requiring it
+    # would lock them out of deleting their own account. Email confirmation
+    # plus their authenticated session is the auth factor in that case.
+    if user.connected_services.empty? && !user.authenticate(params[:current_password].to_s)
+      redirect_to profile_path, alert: "Incorrect password."
+      return
+    end
+
+    if user.admin? && !User.where(admin: true).where.not(id: user.id).exists?
+      redirect_to profile_path, alert: "You're the only admin — promote another admin from the Rails console before deleting your account."
+      return
+    end
+
+    User.transaction { user.destroy! }
+
+    cookies.delete(:session_id)
+    Current.session = nil
+    redirect_to root_path, notice: "Your account has been deleted."
   end
 
   private

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -8,8 +8,9 @@ class RegistrationsController < ApplicationController
   def create
     @user = User.new(registration_params)
     if @user.save
+      EmailVerificationMailer.verify(@user).deliver_later
       start_new_session_for @user
-      redirect_to after_authentication_url, notice: "Welcome!"
+      redirect_to after_authentication_url
     else
       flash.now[:alert] = @user.errors.full_messages.first
       render :new, status: :unprocessable_entity

--- a/app/controllers/sessions/omni_auths_controller.rb
+++ b/app/controllers/sessions/omni_auths_controller.rb
@@ -1,0 +1,59 @@
+module Sessions
+  class OmniAuthsController < ApplicationController
+    allow_unauthenticated_access only: %i[ create failure ]
+    skip_before_action :require_username_set, only: %i[ create failure ]
+
+    def create
+      auth = request.env["omniauth.auth"]
+      return redirect_failure("Sign-in failed.") if auth.blank?
+
+      provider = auth.provider.to_s
+      uid      = auth.uid.to_s
+      email    = auth.info&.email.to_s.downcase.presence
+      verified = auth.info&.email_verified
+      verified = auth.extra&.id_info&.dig("email_verified") if verified.nil?
+
+      service = ConnectedService.find_by(provider: provider, uid: uid)
+      if service
+        sign_in_and_redirect(service.user)
+        return
+      end
+
+      return redirect_failure("Google did not provide an email address.") unless email
+      return redirect_failure("Google did not confirm that email is yours.") unless verified
+
+      ActiveRecord::Base.transaction do
+        user = User.find_by(email_address: email) || build_oauth_user(email)
+        user.connected_services.build(provider: provider, uid: uid, email: email)
+        user.save!
+        sign_in_and_redirect(user)
+      end
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.warn("[oauth] callback failed: #{e.record.errors.full_messages.to_sentence}")
+      redirect_failure("Sign-in failed: #{e.record.errors.full_messages.first}")
+    end
+
+    def failure
+      redirect_failure(params[:message].presence || "Sign-in cancelled or failed.")
+    end
+
+    private
+      def build_oauth_user(email)
+        password = SecureRandom.hex(24)
+        User.new(email_address: email, password: password, password_confirmation: password)
+      end
+
+      def sign_in_and_redirect(user)
+        start_new_session_for(user)
+        if user.pending_username_setup?
+          redirect_to setup_username_profile_path, notice: "Welcome! Pick a username to finish setting up."
+        else
+          redirect_to after_authentication_url, notice: "Signed in."
+        end
+      end
+
+      def redirect_failure(message)
+        redirect_to new_session_path, alert: message
+      end
+  end
+end

--- a/app/controllers/sessions/omni_auths_controller.rb
+++ b/app/controllers/sessions/omni_auths_controller.rb
@@ -2,6 +2,7 @@ module Sessions
   class OmniAuthsController < ApplicationController
     allow_unauthenticated_access only: %i[ create failure ]
     skip_before_action :require_username_set, only: %i[ create failure ]
+    skip_before_action :require_email_verified
 
     def create
       auth = request.env["omniauth.auth"]

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,7 @@
 class SessionsController < ApplicationController
   allow_unauthenticated_access only: %i[ new create ]
   skip_before_action :require_username_set, only: :destroy
+  skip_before_action :require_email_verified
   rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_path, alert: "Try again later." }
 
   def new

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,6 @@
 class SessionsController < ApplicationController
   allow_unauthenticated_access only: %i[ new create ]
+  skip_before_action :require_username_set, only: :destroy
   rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_path, alert: "Try again later." }
 
   def new

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: "LandscapeGuessr <landscapeguessr@gmail.com>"
   layout "mailer"
 end

--- a/app/mailers/email_verification_mailer.rb
+++ b/app/mailers/email_verification_mailer.rb
@@ -1,0 +1,6 @@
+class EmailVerificationMailer < ApplicationMailer
+  def verify(user)
+    @user = user
+    mail subject: "Verify your email", to: user.email_address
+  end
+end

--- a/app/models/challenge_image.rb
+++ b/app/models/challenge_image.rb
@@ -1,4 +1,15 @@
 class ChallengeImage < ApplicationRecord
   belongs_to :challenge
   belongs_to :image
+
+  # Symmetrical to GameImage / ImageSetItem: when the last challenge_image
+  # referencing an Image is destroyed and nothing else points at it,
+  # Image#purge_if_orphan! cleans up the row and its S3 blob.
+  after_destroy :purge_image_if_orphan
+
+  private
+
+  def purge_image_if_orphan
+    image&.purge_if_orphan!
+  end
 end

--- a/app/models/connected_service.rb
+++ b/app/models/connected_service.rb
@@ -1,0 +1,6 @@
+class ConnectedService < ApplicationRecord
+  belongs_to :user
+
+  validates :provider, presence: true
+  validates :uid, presence: true, uniqueness: { scope: :provider }
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -2,6 +2,7 @@ class Image < ApplicationRecord
   has_one_attached :photo
   has_many :guesses, dependent: :destroy
   has_many :game_images, dependent: :destroy
+  has_many :challenge_images, dependent: :destroy
   has_many :image_set_items, dependent: :destroy
   has_many :image_sets, through: :image_set_items
 
@@ -58,6 +59,7 @@ class Image < ApplicationRecord
   def purge_if_orphan!
     return if image_set_items.exists?
     return if game_images.exists?
+    return if challenge_images.exists?
     return if guesses.exists?
     destroy
   end

--- a/app/models/image_set.rb
+++ b/app/models/image_set.rb
@@ -27,7 +27,11 @@ class ImageSet < ApplicationRecord
   validate :system_default_has_no_user
   validate :only_one_system_default, if: :is_system_default?
 
-  before_destroy :capture_member_image_ids
+  # `prepend: true` so this runs BEFORE the `dependent: :delete_all` on
+  # image_set_items (declared above) — dependent destroy strategies are
+  # before_destroy callbacks added at class-load time in declaration
+  # order, so without prepend our snapshot would see an empty join table.
+  before_destroy :capture_member_image_ids, prepend: true
   after_destroy  :sweep_orphan_images
 
   scope :public_catalog, -> { where(visibility: "public") }

--- a/app/models/image_set.rb
+++ b/app/models/image_set.rb
@@ -86,6 +86,7 @@ class ImageSet < ApplicationRecord
       orphan_ids = Image.where(id: chunk)
                         .where.missing(:image_set_items)
                         .where.missing(:game_images)
+                        .where.missing(:challenge_images)
                         .where.missing(:guesses)
                         .pluck(:id)
       next if orphan_ids.empty?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,22 @@ class User < ApplicationRecord
   has_many :image_sets, dependent: :destroy
   has_many :connected_services, dependent: :destroy
 
+  generates_token_for :email_verification, expires_in: 24.hours do
+    email_verified_at
+  end
+
+  def email_verified?
+    email_verified_at.present? || connected_services.any?
+  end
+
+  def email_verification_token
+    generate_token_for(:email_verification)
+  end
+
+  def self.find_by_email_verification_token(token)
+    find_by_token_for(:email_verification, token)
+  end
+
   normalizes :email_address, with: ->(e) { e.strip.downcase }
   normalizes :username, with: ->(u) { u.present? ? u.to_s.strip : nil }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,18 +5,24 @@ class User < ApplicationRecord
   has_many :sessions, dependent: :destroy
   has_many :games, dependent: :destroy
   has_many :image_sets, dependent: :destroy
+  has_many :connected_services, dependent: :destroy
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }
-  normalizes :username, with: ->(u) { u.to_s.strip }
+  normalizes :username, with: ->(u) { u.present? ? u.to_s.strip : nil }
 
   validates :email_address, presence: true,
                             uniqueness: { message: "is invalid" },
                             format: { with: URI::MailTo::EMAIL_REGEXP }
-  validates :username, presence: true,
-                       format: { with: USERNAME_FORMAT,
+  validates :username, presence: true, unless: :pending_username_setup?
+  validates :username, format: { with: USERNAME_FORMAT,
                                  message: "must be 3-20 characters: letters, digits, _ or -" },
-                       uniqueness: { case_sensitive: false }
+                       uniqueness: { case_sensitive: false },
+                       allow_blank: true
   validates :password, length: { minimum: 8 }, allow_nil: true
+
+  def pending_username_setup?
+    username.blank? && connected_services.any?
+  end
 
   def self.find_by_login(login)
     s = login.to_s.strip

--- a/app/views/email_verification_mailer/verify.html.erb
+++ b/app/views/email_verification_mailer/verify.html.erb
@@ -1,0 +1,5 @@
+<p>
+  Verify your email address by visiting
+  <%= link_to "this link", email_verification_url(token: @user.email_verification_token) %>.
+</p>
+<p>This link will expire in 24 hours.</p>

--- a/app/views/email_verification_mailer/verify.text.erb
+++ b/app/views/email_verification_mailer/verify.text.erb
@@ -1,0 +1,4 @@
+Verify your email address by visiting this link:
+<%= email_verification_url(token: @user.email_verification_token) %>
+
+This link will expire in 24 hours.

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,7 +34,11 @@
       </div>
       <div class="flex items-center gap-3">
         <% if authenticated? %>
-          <%= link_to Current.user.username, profile_path, class: "text-gray-700 hover:text-blue-600 font-medium hidden sm:inline" %>
+          <% if Current.user.username.present? %>
+            <%= link_to Current.user.username, profile_path, class: "text-gray-700 hover:text-blue-600 font-medium hidden sm:inline" %>
+          <% else %>
+            <%= link_to "Finish setup", setup_username_profile_path, class: "text-gray-700 hover:text-blue-600 font-medium hidden sm:inline" %>
+          <% end %>
           <%= button_to "Sign out", session_path, method: :delete, class: "btn-secondary text-sm py-1.5" %>
         <% else %>
           <%= link_to "Sign in", new_session_path, class: "btn-secondary text-sm py-1.5" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,6 +54,19 @@
       <% if alert = flash[:alert] %>
         <p class="py-2 px-3 mb-5 bg-red-50 text-red-600 font-medium rounded-md mx-auto md:w-2/3 w-full" id="alert"><%= alert %></p>
       <% end %>
+      <% if authenticated? && !Current.user.email_verified? %>
+        <% if flash[:verify_email] %>
+          <div class="py-2 px-3 mb-5 bg-red-50 text-red-700 font-medium rounded-md mx-auto md:w-2/3 w-full flex justify-between items-center">
+            <span>Please verify your email to access this feature.</span>
+            <%= button_to "Resend verification", email_verification_path, method: :post, class: "text-red-800 underline hover:no-underline text-sm" %>
+          </div>
+        <% else %>
+          <div class="py-2 px-3 mb-5 bg-yellow-50 text-yellow-800 font-medium rounded-md mx-auto md:w-2/3 w-full flex justify-between items-center">
+            <span>Check your inbox and verify your email to unlock all features.</span>
+            <%= button_to "Resend", email_verification_path, method: :post, class: "text-yellow-900 underline hover:no-underline text-sm" %>
+          </div>
+        <% end %>
+      <% end %>
       <%= yield %>
     </main>
 

--- a/app/views/profiles/setup_username.html.erb
+++ b/app/views/profiles/setup_username.html.erb
@@ -1,0 +1,17 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <h1 class="heading-page">Pick a username</h1>
+
+  <p class="muted mb-4">
+    Almost there — choose a username to finish setting up your account.
+  </p>
+
+  <%= form_with model: @user, url: setup_username_profile_path, method: :patch, class: "contents" do |form| %>
+    <div class="my-5">
+      <%= form.text_field :username, required: true, autofocus: true, autocomplete: "username", placeholder: "3-20 chars: letters, digits, _ or -", class: "form-input" %>
+    </div>
+
+    <div class="inline">
+      <%= form.submit "Save", class: "btn-primary w-full sm:w-auto" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -26,4 +26,40 @@
       <%= button_to "Sign out", session_path, method: :delete, class: "btn-secondary text-sm py-2" %>
     </div>
   </section>
+
+  <%# Danger zone %>
+  <section class="space-y-3 pt-4 border-t border-gray-200">
+    <h2 class="heading-section text-red-700">Danger zone</h2>
+    <details class="rounded-md border border-red-200 bg-red-50 p-4">
+      <summary class="cursor-pointer font-medium text-red-800">Delete account</summary>
+      <div class="mt-3 space-y-3 text-sm text-red-900">
+        <p>
+          This permanently deletes your account, all games and guesses you've played,
+          and any image sets you own. Images you uploaded that aren't shared with
+          another user's set or the default set will also be removed.
+        </p>
+        <p class="text-red-800">
+          Other users' games on your public sets are preserved (without the set
+          association). This action cannot be undone.
+        </p>
+        <%= form_with url: profile_path, method: :delete, data: { turbo_confirm: "Permanently delete your account? This cannot be undone." }, class: "space-y-3" do %>
+          <% unless @user.connected_services.exists? %>
+            <div>
+              <label class="block text-xs font-medium text-red-900 mb-1" for="current_password">Current password</label>
+              <%= password_field_tag :current_password, nil, required: true, autocomplete: "current-password", maxlength: 72, class: "form-input" %>
+            </div>
+          <% end %>
+          <div>
+            <label class="block text-xs font-medium text-red-900 mb-1" for="confirm_email">
+              Type your email (<span class="font-mono"><%= @user.email_address %></span>) to confirm
+            </label>
+            <%= email_field_tag :confirm_email, nil, required: true, autocomplete: "off", class: "form-input" %>
+          </div>
+          <div>
+            <%= submit_tag "Permanently delete my account", class: "btn-danger text-sm py-2" %>
+          </div>
+        <% end %>
+      </div>
+    </details>
+  </section>
 </div>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -23,6 +23,14 @@
     </div>
   <% end %>
 
+  <div class="my-6 flex items-center gap-3 text-xs uppercase text-gray-400">
+    <span class="h-px flex-1 bg-gray-200"></span>
+    <span>or</span>
+    <span class="h-px flex-1 bg-gray-200"></span>
+  </div>
+
+  <%= button_to "Sign up with Google", "/auth/google_oauth2", method: :post, data: { turbo: false }, class: "btn-secondary w-full" %>
+
   <p class="mt-6 text-sm text-gray-600">
     Already have an account?
     <%= link_to "Sign in", new_session_path, class: "text-blue-600 underline hover:no-underline" %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -21,6 +21,14 @@
     </div>
   <% end %>
 
+  <div class="my-6 flex items-center gap-3 text-xs uppercase text-gray-400">
+    <span class="h-px flex-1 bg-gray-200"></span>
+    <span>or</span>
+    <span class="h-px flex-1 bg-gray-200"></span>
+  </div>
+
+  <%= button_to "Sign in with Google", "/auth/google_oauth2", method: :post, data: { turbo: false }, class: "btn-secondary w-full" %>
+
   <p class="mt-6 text-sm text-gray-600">
     Don't have an account?
     <%= link_to "Sign up", new_registration_path, class: "text-blue-600 underline hover:no-underline" %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,14 +32,23 @@ Rails.application.configure do
   # the same S3 path as production (requires AWS_ACCESS_KEY_ID/SECRET).
   config.active_storage.service = :local
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Make template changes take effect immediately.
   config.action_mailer.perform_caching = false
 
   # Set localhost to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:         "smtp.gmail.com",
+    port:            587,
+    user_name:       ENV["GMAIL_USERNAME"],
+    password:        ENV["GMAIL_APP_PASSWORD"],
+    authentication:  :plain,
+    enable_starttls: true
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -79,14 +79,16 @@ Rails.application.configure do
   # Set host to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "landscape-guessr-cc7bc949a622.herokuapp.com", protocol: "https" }
 
-  # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.
-  # config.action_mailer.smtp_settings = {
-  #   user_name: Rails.application.credentials.dig(:smtp, :user_name),
-  #   password: Rails.application.credentials.dig(:smtp, :password),
-  #   address: "smtp.example.com",
-  #   port: 587,
-  #   authentication: :plain
-  # }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.smtp_settings = {
+    address:         "smtp.gmail.com",
+    port:            587,
+    user_name:       ENV["GMAIL_USERNAME"],
+    password:        ENV["GMAIL_APP_PASSWORD"],
+    authentication:  :plain,
+    enable_starttls: true
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,18 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :google_oauth2,
+           ENV["GOOGLE_CLIENT_ID"],
+           ENV["GOOGLE_CLIENT_SECRET"],
+           {
+             scope: "email,profile",
+             prompt: "select_account",
+             skip_jwt: false,
+             access_type: "online"
+           }
+end
+
+OmniAuth.config.allowed_request_methods = [ :post ]
+OmniAuth.config.silence_get_warning = true
+
+OmniAuth.config.on_failure = proc do |env|
+  OmniAuth::FailureEndpoint.new(env).redirect_to_failure
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   resources :passwords, param: :token, only: %i[ new create edit update ]
   resource :registration, only: %i[ new create ]
   resource :email_verification, only: %i[ show create ]
-  resource :profile, only: :show do
+  resource :profile, only: %i[ show destroy ] do
     get   :setup_username
     patch :setup_username, action: :update_username
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resource :session, only: %i[ new create destroy ]
   resources :passwords, param: :token, only: %i[ new create edit update ]
   resource :registration, only: %i[ new create ]
+  resource :email_verification, only: %i[ show create ]
   resource :profile, only: :show do
     get   :setup_username
     patch :setup_username, action: :update_username

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,13 @@ Rails.application.routes.draw do
   resource :session, only: %i[ new create destroy ]
   resources :passwords, param: :token, only: %i[ new create edit update ]
   resource :registration, only: %i[ new create ]
-  resource :profile, only: :show
+  resource :profile, only: :show do
+    get   :setup_username
+    patch :setup_username, action: :update_username
+  end
+
+  get "/auth/:provider/callback", to: "sessions/omni_auths#create", as: :omniauth_callback
+  get "/auth/failure",            to: "sessions/omni_auths#failure"
 
   resources :guesses
   resources :games do

--- a/db/migrate/20260508182129_create_connected_services.rb
+++ b/db/migrate/20260508182129_create_connected_services.rb
@@ -1,0 +1,14 @@
+class CreateConnectedServices < ActiveRecord::Migration[8.1]
+  def change
+    create_table :connected_services do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :provider, null: false
+      t.string :uid, null: false
+      t.string :email
+
+      t.timestamps
+    end
+
+    add_index :connected_services, [ :provider, :uid ], unique: true
+  end
+end

--- a/db/migrate/20260508182130_allow_null_username_on_users.rb
+++ b/db/migrate/20260508182130_allow_null_username_on_users.rb
@@ -1,0 +1,5 @@
+class AllowNullUsernameOnUsers < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :users, :username, true
+  end
+end

--- a/db/migrate/20260512000003_add_token_to_challenges.rb
+++ b/db/migrate/20260512000003_add_token_to_challenges.rb
@@ -1,10 +1,13 @@
 class AddTokenToChallenges < ActiveRecord::Migration[8.1]
-  # Historical no-op. Earlier in this branch's lifetime CreateChallenges
-  # didn't include `token`, so this migration added it. CreateChallenges
-  # was later edited to include `token` directly, which left this one as
-  # a duplicate that would `PG::DuplicateColumn` on any fresh
-  # `db:migrate`. Environments that already recorded this version as up
-  # (Heroku, team devs) keep skipping it; fresh setups now succeed.
+  # The committed version of CreateChallenges already adds the `token`
+  # column and unique index, so this migration would raise
+  # PG::DuplicateColumn on any clean run. Guard the operations so the
+  # migration is a no-op on clean environments and only fills in `token`
+  # for legacy databases where it's missing.
   def change
+    unless column_exists?(:challenges, :token)
+      add_column :challenges, :token, :string, null: false, default: ""
+      add_index  :challenges, :token, unique: true
+    end
   end
 end

--- a/db/migrate/20260512000003_add_token_to_challenges.rb
+++ b/db/migrate/20260512000003_add_token_to_challenges.rb
@@ -1,6 +1,10 @@
 class AddTokenToChallenges < ActiveRecord::Migration[8.1]
+  # Historical no-op. Earlier in this branch's lifetime CreateChallenges
+  # didn't include `token`, so this migration added it. CreateChallenges
+  # was later edited to include `token` directly, which left this one as
+  # a duplicate that would `PG::DuplicateColumn` on any fresh
+  # `db:migrate`. Environments that already recorded this version as up
+  # (Heroku, team devs) keep skipping it; fresh setups now succeed.
   def change
-    add_column :challenges, :token, :string, null: false, default: ""
-    add_index  :challenges, :token, unique: true
   end
 end

--- a/db/migrate/20260512000004_remove_stale_columns_from_challenges.rb
+++ b/db/migrate/20260512000004_remove_stale_columns_from_challenges.rb
@@ -1,6 +1,11 @@
 class RemoveStaleColumnsFromChallenges < ActiveRecord::Migration[8.1]
+  # The committed version of CreateChallenges never adds challengee_id or
+  # status, so on any environment that ran the migrations in order these
+  # columns don't exist and remove_column would raise. Guard each removal
+  # so the migration is a no-op on clean environments and only cleans up
+  # legacy databases where the columns somehow exist.
   def change
-    remove_column :challenges, :challengee_id, :bigint
-    remove_column :challenges, :status, :string
+    remove_column :challenges, :challengee_id, :bigint if column_exists?(:challenges, :challengee_id)
+    remove_column :challenges, :status,        :string if column_exists?(:challenges, :status)
   end
 end

--- a/db/migrate/20260513000001_add_email_verified_at_to_users.rb
+++ b/db/migrate/20260513000001_add_email_verified_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddEmailVerifiedAtToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :email_verified_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_06_044001) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_08_182130) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -40,6 +40,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_044001) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "connected_services", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "email"
+    t.string "provider", null: false
+    t.string "uid", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["provider", "uid"], name: "index_connected_services_on_provider_and_uid", unique: true
+    t.index ["user_id"], name: "index_connected_services_on_user_id"
   end
 
   create_table "game_images", force: :cascade do |t|
@@ -126,13 +137,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_044001) do
     t.string "email_address", null: false
     t.string "password_digest", null: false
     t.datetime "updated_at", null: false
-    t.string "username", null: false
+    t.string "username"
     t.index "lower((username)::text)", name: "index_users_on_lower_username", unique: true
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "connected_services", "users"
   add_foreign_key "game_images", "games"
   add_foreign_key "game_images", "images"
   add_foreign_key "games", "image_sets"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_08_182130) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -135,6 +135,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_182130) do
     t.boolean "admin", default: false, null: false
     t.datetime "created_at", null: false
     t.string "email_address", null: false
+    t.datetime "email_verified_at"
     t.string "password_digest", null: false
     t.datetime "updated_at", null: false
     t.string "username"

--- a/test/controllers/email_verification_gating_test.rb
+++ b/test/controllers/email_verification_gating_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+class EmailVerificationGatingTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:alice)
+    @user.update!(email_verified_at: nil)
+  end
+
+  test "unverified user is blocked from games" do
+    sign_in_as @user
+    get games_url
+    assert_redirected_to root_path
+  end
+
+  test "unverified user is blocked from creating image sets" do
+    sign_in_as @user
+    get image_sets_url
+    assert_redirected_to root_path
+  end
+
+  test "unverified user can still view home page" do
+    sign_in_as @user
+    get root_url
+    assert_response :success
+  end
+
+  test "unverified user can still view public images" do
+    sign_in_as @user
+    get images_url
+    assert_response :success
+  end
+
+  test "unverified user can still access practice mode" do
+    sign_in_as @user
+    get practice_url
+    assert_response :success
+  end
+
+  test "verified user can access games" do
+    @user.update!(email_verified_at: Time.current)
+    sign_in_as @user
+    get games_url
+    assert_response :success
+  end
+end

--- a/test/controllers/email_verifications_controller_test.rb
+++ b/test/controllers/email_verifications_controller_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+
+class EmailVerificationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:alice)
+  end
+
+  # --- show (clicking the verification link) ---
+
+  test "valid token verifies the user" do
+    @user.update!(email_verified_at: nil)
+    token = @user.generate_token_for(:email_verification)
+
+    get email_verification_url(token: token)
+    assert_redirected_to root_path
+    assert_equal "Email verified successfully!", flash[:notice]
+    assert_not_nil @user.reload.email_verified_at
+  end
+
+  test "expired or invalid token shows error" do
+    get email_verification_url(token: "bogus")
+    assert_redirected_to root_path
+    assert_equal "Verification link is invalid or has expired.", flash[:alert]
+  end
+
+  test "token becomes invalid after user is already verified" do
+    @user.update!(email_verified_at: nil)
+    token = @user.generate_token_for(:email_verification)
+    @user.update!(email_verified_at: Time.current)
+
+    get email_verification_url(token: token)
+    assert_redirected_to root_path
+    assert_match /invalid or has expired/, flash[:alert]
+  end
+
+  # --- create (resend verification email) ---
+
+  test "resend sends email for unverified user" do
+    @user.update!(email_verified_at: nil)
+    sign_in_as @user
+
+    assert_enqueued_emails 1 do
+      post email_verification_url
+    end
+    assert_redirected_to root_path
+    assert_match /Verification email sent/, flash[:notice]
+  end
+
+  test "resend skips sending for already-verified user" do
+    sign_in_as @user
+
+    assert_no_enqueued_emails do
+      post email_verification_url
+    end
+    assert_redirected_to root_path
+    assert_match /already verified/, flash[:notice]
+  end
+
+  test "resend requires authentication" do
+    post email_verification_url
+    assert_redirected_to new_session_url
+  end
+end

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -174,6 +174,24 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
            "image shared with another user's set must survive deletion"
   end
 
+  test "destroy preserves images referenced by another user's challenge" do
+    # Bob builds a challenge that snapshots alice_only via challenge_images.
+    # Alice's image_set sweep must not destroy the image while Bob's
+    # challenge still references it.
+    bob_challenge = Challenge.create!(challenger: @bob, image_set: image_sets(:default))
+    ChallengeImage.create!(challenge: bob_challenge, image: images(:alice_only), position: 1)
+    shared_id = images(:alice_only).id
+
+    sign_in_as @alice
+    delete profile_url, params: {
+      confirm_email: @alice.email_address,
+      current_password: "password123"
+    }
+
+    assert Image.exists?(shared_id),
+           "image referenced by another user's challenge must survive deletion"
+  end
+
   test "destroy preserves another user's games on the deleted user's public set, nullifying image_set_id" do
     alice_public = image_sets(:alice_public)
     bob_game = Game.create!(user: @bob, image_set: alice_public, status: "completed",

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -1,0 +1,275 @@
+require "test_helper"
+
+class ProfilesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @alice = users(:alice)
+    @bob   = users(:bob)
+    @admin = users(:admin)
+  end
+
+  # --- show ---
+
+  test "unauthenticated user is redirected from /profile" do
+    get profile_url
+    assert_redirected_to new_session_url
+  end
+
+  test "authenticated user sees their profile with the delete-account form" do
+    sign_in_as @alice
+    get profile_url
+    assert_response :success
+    assert_select "form[action=?][method=post]", profile_path do
+      assert_select "input[name=_method][value=delete]"
+      assert_select "input[name=confirm_email]"
+      assert_select "input[name=current_password]"
+    end
+  end
+
+  # --- destroy: auth ---
+
+  test "unauthenticated DELETE /profile is redirected to login" do
+    delete profile_url, params: { confirm_email: "anything@example.com" }
+    assert_redirected_to new_session_url
+    assert_not_nil User.find_by(id: @alice.id)
+  end
+
+  # --- destroy: confirmation checks ---
+
+  test "DELETE without confirm_email is rejected" do
+    sign_in_as @alice
+    assert_no_difference -> { User.count } do
+      delete profile_url, params: { current_password: "password123" }
+    end
+    assert_redirected_to profile_path
+    assert_match(/email/i, flash[:alert])
+  end
+
+  test "DELETE with wrong confirm_email is rejected" do
+    sign_in_as @alice
+    assert_no_difference -> { User.count } do
+      delete profile_url, params: {
+        confirm_email: "not-alice@example.com",
+        current_password: "password123"
+      }
+    end
+    assert_redirected_to profile_path
+  end
+
+  test "DELETE with wrong password is rejected" do
+    sign_in_as @alice
+    assert_no_difference -> { User.count } do
+      delete profile_url, params: {
+        confirm_email: @alice.email_address,
+        current_password: "wrong-password"
+      }
+    end
+    assert_redirected_to profile_path
+    assert_match(/password/i, flash[:alert])
+  end
+
+  test "confirm_email comparison is case-insensitive and trims whitespace" do
+    sign_in_as @alice
+    assert_difference -> { User.count } => -1 do
+      delete profile_url, params: {
+        confirm_email: "  #{@alice.email_address.upcase}  ",
+        current_password: "password123"
+      }
+    end
+    assert_redirected_to root_path
+  end
+
+  # --- destroy: happy path ---
+
+  test "DELETE with correct password + email destroys account and signs out" do
+    sign_in_as @alice
+    alice_id = @alice.id
+    sessions_before = Session.where(user_id: alice_id).count
+    assert_difference -> { User.count } => -1,
+                      -> { Session.where(user_id: alice_id).count } => -sessions_before do
+      delete profile_url, params: {
+        confirm_email: @alice.email_address,
+        current_password: "password123"
+      }
+    end
+    assert_redirected_to root_path
+    assert_nil User.find_by(id: alice_id)
+    # Subsequent request behaves as logged-out
+    get profile_url
+    assert_redirected_to new_session_url
+  end
+
+  test "destroy cascades to games, guesses, game_images, and owned image_sets" do
+    sign_in_as @alice
+    alice_game_ids = @alice.games.pluck(:id)
+    alice_set_ids  = @alice.image_sets.pluck(:id)
+    assert alice_game_ids.any?
+    assert alice_set_ids.any?
+
+    delete profile_url, params: {
+      confirm_email: @alice.email_address,
+      current_password: "password123"
+    }
+    assert_redirected_to root_path
+
+    assert_empty Game.where(id: alice_game_ids)
+    assert_empty Guess.where(game_id: alice_game_ids)
+    assert_empty GameImage.where(game_id: alice_game_ids)
+    assert_empty ImageSet.where(id: alice_set_ids)
+  end
+
+  # --- destroy: shared-data preservation ---
+
+  test "destroy preserves the system default image set" do
+    sign_in_as @alice
+    default_set_id = image_sets(:default).id
+
+    delete profile_url, params: {
+      confirm_email: @alice.email_address,
+      current_password: "password123"
+    }
+
+    assert ImageSet.exists?(default_set_id), "system default ImageSet must survive"
+  end
+
+  test "destroy preserves images shared with the system default set" do
+    sign_in_as @alice
+    # image "one" lives in default + alice_private + alice_public — survives
+    shared_image_id = images(:one).id
+
+    delete profile_url, params: {
+      confirm_email: @alice.email_address,
+      current_password: "password123"
+    }
+
+    assert Image.exists?(shared_image_id), "shared image (also in default set) must survive"
+  end
+
+  test "destroy removes images that lived only in the deleted user's sets" do
+    sign_in_as @alice
+    # alice_only image is only in alice_private — orphan-sweep should destroy it
+    alice_only_id = images(:alice_only).id
+
+    delete profile_url, params: {
+      confirm_email: @alice.email_address,
+      current_password: "password123"
+    }
+
+    assert_nil Image.find_by(id: alice_only_id),
+               "image only in deleted user's set should be cleaned up"
+  end
+
+  test "destroy preserves images that also live in another user's set" do
+    # Move alice_only into bob's brand-new set so it's shared cross-user
+    bob_set = ImageSet.create!(user: @bob, name: "Bob's Set", visibility: "private")
+    ImageSetItem.create!(image_set: bob_set, image: images(:alice_only))
+    shared_id = images(:alice_only).id
+
+    sign_in_as @alice
+    delete profile_url, params: {
+      confirm_email: @alice.email_address,
+      current_password: "password123"
+    }
+
+    assert Image.exists?(shared_id),
+           "image shared with another user's set must survive deletion"
+  end
+
+  test "destroy preserves another user's games on the deleted user's public set, nullifying image_set_id" do
+    alice_public = image_sets(:alice_public)
+    bob_game = Game.create!(user: @bob, image_set: alice_public, status: "completed",
+                            score: 1234, completed_at: 1.hour.ago)
+
+    sign_in_as @alice
+    delete profile_url, params: {
+      confirm_email: @alice.email_address,
+      current_password: "password123"
+    }
+
+    bob_game.reload
+    assert_equal @bob.id, bob_game.user_id
+    assert_nil bob_game.image_set_id, "ImageSet#dependent: :nullify should clear the FK"
+  end
+
+  test "destroy preserves other users' connected services" do
+    @bob.connected_services.create!(provider: "google_oauth2", uid: "bob-uid", email: @bob.email_address)
+    @alice.connected_services.create!(provider: "google_oauth2", uid: "alice-uid", email: @alice.email_address)
+
+    sign_in_as @alice
+    delete profile_url, params: {
+      confirm_email: @alice.email_address,
+      current_password: "password123"
+    }
+
+    assert ConnectedService.exists?(provider: "google_oauth2", uid: "bob-uid")
+    assert_not ConnectedService.exists?(provider: "google_oauth2", uid: "alice-uid")
+  end
+
+  # --- destroy: admin edge cases ---
+
+  test "sole admin cannot delete their account" do
+    sign_in_as @admin
+    assert_no_difference -> { User.count } do
+      delete profile_url, params: {
+        confirm_email: @admin.email_address,
+        current_password: "password123"
+      }
+    end
+    assert_redirected_to profile_path
+    assert_match(/admin/i, flash[:alert])
+  end
+
+  test "admin can delete their account if another admin exists" do
+    User.create!(email_address: "second-admin@example.com", username: "secondadmin",
+                 password: "password123", admin: true, email_verified_at: 1.day.ago)
+    sign_in_as @admin
+    assert_difference -> { User.count } => -1 do
+      delete profile_url, params: {
+        confirm_email: @admin.email_address,
+        current_password: "password123"
+      }
+    end
+  end
+
+  # --- destroy: OAuth-only user (no password_digest) ---
+
+  # OAuth users always have an auto-generated random password they never
+  # see (see Sessions::OmniAuthsController#build_oauth_user). The delete
+  # form skips the password input for users with a ConnectedService and
+  # the controller skips the password check.
+  test "OAuth-linked user can delete without providing a password" do
+    oauth_user = create_oauth_user("oauth@example.com", "oauthuser", uid: "oauth-uid")
+    sign_in_as oauth_user
+
+    # No current_password in params — the controller must skip the check
+    # since the user has a ConnectedService.
+    assert_difference -> { User.count } => -1 do
+      delete profile_url, params: { confirm_email: oauth_user.email_address }
+    end
+    assert_redirected_to root_path
+  end
+
+  test "OAuth-linked user with wrong email confirmation is rejected" do
+    oauth_user = create_oauth_user("oauth2@example.com", "oauthuser2", uid: "oauth-uid-2")
+    sign_in_as oauth_user
+
+    assert_no_difference -> { User.count } do
+      delete profile_url, params: { confirm_email: "wrong@example.com" }
+    end
+    assert_redirected_to profile_path
+  end
+
+  private
+
+  # OAuth users in production get an auto-generated password they never
+  # see (see Sessions::OmniAuthsController#build_oauth_user); for the
+  # test we pick a known one so sign_in_as can POST through the session
+  # endpoint, but the "OAuth-linked" branch in the controller fires based
+  # on ConnectedService presence, not whether the password is known.
+  def create_oauth_user(email, username, uid:)
+    user = User.create!(email_address: email, username: username,
+                        password: "password123", password_confirmation: "password123",
+                        email_verified_at: 1.day.ago)
+    user.connected_services.create!(provider: "google_oauth2", uid: uid, email: email)
+    user
+  end
+end

--- a/test/controllers/sessions/omni_auths_controller_test.rb
+++ b/test/controllers/sessions/omni_auths_controller_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+class Sessions::OmniAuthsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    OmniAuth.config.test_mode = true
+  end
+
+  teardown do
+    OmniAuth.config.mock_auth[:google_oauth2] = nil
+    OmniAuth.config.test_mode = false
+  end
+
+  def mock_google(uid:, email:, email_verified: true)
+    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+      provider: "google_oauth2",
+      uid: uid,
+      info: { email: email, email_verified: email_verified, name: "Test" }
+    )
+    Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:google_oauth2]
+  end
+
+  test "existing connected_service signs in that user" do
+    user = users(:alice)
+    user.connected_services.create!(provider: "google_oauth2", uid: "google-123")
+    mock_google(uid: "google-123", email: "alice@example.com")
+
+    get "/auth/google_oauth2/callback"
+    assert_redirected_to root_url
+    follow_redirect!
+    assert_response :success
+  end
+
+  test "auto-links Google identity to existing user when email_verified is true" do
+    user = users(:alice)
+    assert_equal 0, user.connected_services.count
+    mock_google(uid: "google-NEW", email: "alice@example.com", email_verified: true)
+
+    assert_difference -> { ConnectedService.count }, 1 do
+      get "/auth/google_oauth2/callback"
+    end
+    assert_redirected_to root_url
+    assert_equal user, ConnectedService.find_by(provider: "google_oauth2", uid: "google-NEW").user
+  end
+
+  test "refuses to auto-link when email_verified is false" do
+    users(:alice)
+    mock_google(uid: "google-XYZ", email: "alice@example.com", email_verified: false)
+
+    assert_no_difference -> { ConnectedService.count } do
+      get "/auth/google_oauth2/callback"
+    end
+    assert_redirected_to new_session_path
+    assert_match(/confirm/i, flash[:alert])
+  end
+
+  test "creates new user with no username and redirects to setup" do
+    mock_google(uid: "google-NEW2", email: "newperson@example.com", email_verified: true)
+
+    assert_difference -> { User.count }, 1 do
+      assert_difference -> { ConnectedService.count }, 1 do
+        get "/auth/google_oauth2/callback"
+      end
+    end
+
+    user = User.find_by(email_address: "newperson@example.com")
+    assert_nil user.username
+    assert_redirected_to setup_username_profile_path
+  end
+
+  test "missing email is rejected" do
+    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+      provider: "google_oauth2", uid: "no-email", info: { email: nil, email_verified: true }
+    )
+    Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:google_oauth2]
+
+    get "/auth/google_oauth2/callback"
+    assert_redirected_to new_session_path
+  end
+
+  test "failure path redirects with alert" do
+    get "/auth/failure"
+    assert_redirected_to new_session_path
+    assert flash[:alert].present?
+  end
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -2,14 +2,17 @@ alice:
   email_address: alice@example.com
   username: alice
   password_digest: <%= BCrypt::Password.create("password123") %>
+  email_verified_at: <%= 1.day.ago %>
 
 bob:
   email_address: bob@example.com
   username: bob
   password_digest: <%= BCrypt::Password.create("password123") %>
+  email_verified_at: <%= 1.day.ago %>
 
 admin:
   email_address: admin@example.com
   username: admin
   password_digest: <%= BCrypt::Password.create("password123") %>
   admin: true
+  email_verified_at: <%= 1.day.ago %>

--- a/test/models/connected_service_test.rb
+++ b/test/models/connected_service_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class ConnectedServiceTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:alice)
+  end
+
+  test "valid attributes save" do
+    cs = @user.connected_services.build(provider: "google_oauth2", uid: "abc123", email: "a@b.com")
+    assert cs.valid?
+  end
+
+  test "requires provider" do
+    cs = @user.connected_services.build(uid: "abc123")
+    assert_not cs.valid?
+  end
+
+  test "requires uid" do
+    cs = @user.connected_services.build(provider: "google_oauth2")
+    assert_not cs.valid?
+  end
+
+  test "uid is unique per provider" do
+    @user.connected_services.create!(provider: "google_oauth2", uid: "abc123")
+    other = users(:bob).connected_services.build(provider: "google_oauth2", uid: "abc123")
+    assert_not other.valid?
+  end
+
+  test "same uid is allowed across different providers" do
+    @user.connected_services.create!(provider: "google_oauth2", uid: "abc123")
+    other = @user.connected_services.build(provider: "github", uid: "abc123")
+    assert other.valid?
+  end
+
+  test "deleting a user destroys their connected services" do
+    @user.connected_services.create!(provider: "google_oauth2", uid: "abc123")
+    assert_difference -> { ConnectedService.count }, -1 do
+      @user.destroy
+    end
+  end
+end

--- a/test/models/user_email_verification_test.rb
+++ b/test/models/user_email_verification_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class UserEmailVerificationTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:alice)
+  end
+
+  test "email_verified? is true when email_verified_at is set" do
+    @user.email_verified_at = Time.current
+    assert @user.email_verified?
+  end
+
+  test "email_verified? is true when user has connected services (OAuth)" do
+    @user.email_verified_at = nil
+    @user.connected_services.build(provider: "google_oauth2", uid: "123")
+    assert @user.email_verified?
+  end
+
+  test "email_verified? is false when no verification and no connected services" do
+    @user.email_verified_at = nil
+    @user.connected_services.clear
+    assert_not @user.email_verified?
+  end
+
+  test "generates and finds by email verification token" do
+    @user.update!(email_verified_at: nil)
+    token = @user.generate_token_for(:email_verification)
+    assert_equal @user, User.find_by_email_verification_token(token)
+  end
+
+  test "token invalidates after email_verified_at changes" do
+    @user.update!(email_verified_at: nil)
+    token = @user.generate_token_for(:email_verification)
+    @user.update!(email_verified_at: Time.current)
+    assert_nil User.find_by_email_verification_token(token)
+  end
+
+  test "bogus token returns nil" do
+    assert_nil User.find_by_email_verification_token("not-a-real-token")
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -68,6 +68,28 @@ class UserTest < ActiveSupport::TestCase
     assert dup.errors[:username].present?
   end
 
+  # OAuth-pending username (created via Google sign-in, no username yet)
+  test "user with no username but a connected_service is valid" do
+    user = User.new(@attrs.merge(username: nil))
+    user.connected_services.build(provider: "google_oauth2", uid: "abc")
+    assert user.valid?
+  end
+
+  test "user with no username and no connected_service is invalid" do
+    user = User.new(@attrs.merge(username: nil))
+    assert_not user.valid?
+    assert user.errors[:username].present?
+  end
+
+  test "pending_username_setup? true only when username blank AND has connected_service" do
+    user = User.new(@attrs.merge(username: nil))
+    user.connected_services.build(provider: "google_oauth2", uid: "abc")
+    assert user.pending_username_setup?
+
+    user2 = User.new(@attrs)
+    assert_not user2.pending_username_setup?
+  end
+
   # Password
   test "rejects password shorter than 8 chars" do
     user = User.new(@attrs.merge(password: "short"))


### PR DESCRIPTION
Three auth features bundled on this branch.

## What's in here
- **Google sign-in** via OmniAuth (`/auth/google_oauth2`). Adds `ConnectedService` model.
- **Email verification** via Gmail SMTP. New users must confirm before playing; OAuth users are auto-verified.
- **Account deletion** at `/profile` (danger zone). Cascade-destroys the user's sessions, games, image sets, and orphan-only images; preserves shared data (system-default set, other users' sets, other users' games on this user's public set).

## Required before merging

**Migrations** (run on any environment after pulling):
```
bin/rails db:migrate
```
Adds: `connected_services` table, nullable `username` on `users`, `email_verified_at` on `users`.

Heroku env vars (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GMAIL_USERNAME`, `GMAIL_APP_PASSWORD`) are already set.

## Notable fix
Latent bug in `ImageSet`: `capture_member_image_ids` needed `prepend: true` to snapshot before `dependent: :delete_all` wipes the join rows. The orphan-image sweep was a no-op for both account deletion and the existing `ImageSet#destroy` controller path.

## Test plan
- [ ] `bin/rails db:migrate` succeeds
- [ ] Sign up with password → receive verification email → confirm → can start games
- [ ] Sign up with Google → land on username setup → pick username → can play
- [ ] Profile → Danger zone → delete account; confirm cascade and that other users' data is untouched
- [ ] Sole admin cannot delete themselves