### PR TITLE
Fix scan_ruby CI and post-merge fallout from PR #81

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
       bigdecimal (>= 3.1, < 5)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -562,7 +562,7 @@ CHECKSUMS
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
   multi_xml (0.9.1) sha256=7ce766b59c17241ed62976caeae1fae9b2431b263398c35396239a68c4a64e57
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
-  net-imap (0.6.3) sha256=9bab75f876596d09ee7bf911a291da478e0cd6badc54dfb82874855ccc82f2ad
+  net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-scp (4.1.0) sha256=a99b0b92a1e5d360b0de4ffbf2dc0c91531502d3d4f56c28b0139a7c093d1a5d

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,28 +23,6 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
-    <nav aria-label="Primary" class="container mx-auto px-5 pt-5 flex justify-between items-center text-sm">
-      <div class="flex items-center gap-5">
-        <%= link_to "Landscape Guessr", root_path, class: "font-bold" %>
-        <% if authenticated? %>
-          <%= link_to "Games", games_path, class: "text-gray-700 hover:text-blue-600 font-medium" %>
-          <%= link_to "Image Sets", image_sets_path, class: "text-gray-700 hover:text-blue-600 font-medium" %>
-          <%= link_to "Challenges", challenges_path, class: "text-gray-700 hover:text-blue-600 font-medium" %>
-        <% end %>
-      </div>
-      <div class="flex items-center gap-3">
-        <% if authenticated? %>
-          <% if Current.user.username.present? %>
-            <%= link_to Current.user.username, profile_path, class: "text-gray-700 hover:text-blue-600 font-medium hidden sm:inline" %>
-          <% else %>
-            <%= link_to "Finish setup", setup_username_profile_path, class: "text-gray-700 hover:text-blue-600 font-medium hidden sm:inline" %>
-          <% end %>
-          <%= button_to "Sign out", session_path, method: :delete, class: "btn-secondary text-sm py-1.5" %>
-        <% else %>
-          <%= link_to "Sign in", new_session_path, class: "btn-secondary text-sm py-1.5" %>
-          <%= link_to "Sign up", new_registration_path, class: "btn-primary text-sm py-1.5" %>
-        <% end %>
   <body class="font-sans antialiased bg-white text-forest-900 min-h-screen flex flex-col">
 
     <header class="sticky top-0 z-20 bg-white/95 backdrop-blur-sm border-b border-forest-100"

--- a/db/migrate/20260515120000_backfill_email_verified_at.rb
+++ b/db/migrate/20260515120000_backfill_email_verified_at.rb
@@ -1,0 +1,15 @@
+class BackfillEmailVerifiedAt < ActiveRecord::Migration[8.0]
+  def up
+    # Mark every user that pre-existed the email-verification feature as
+    # verified, so they don't get locked out of features gated on it.
+    execute(<<~SQL.squish)
+      UPDATE users
+      SET email_verified_at = created_at
+      WHERE email_verified_at IS NULL
+    SQL
+  end
+
+  def down
+    # Irreversible: we can't distinguish backfilled users from genuinely-verified ones.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_13_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_15_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 


### PR DESCRIPTION
## Summary

Three fixes consolidated into one PR:

1. **`chore(deps): bump net-imap 0.6.3 -> 0.6.4`** — resolves 5 CVEs flagged by `bin/bundler-audit`, which was failing the `scan_ruby` CI job:
   - GHSA-q2mw-fvj9-vvcw (quadratic complexity reading response literals)
   - GHSA-vcgp-9326-pqcp (STARTTLS stripping via invalid response timing)
   - GHSA-87pf-fpwv-p7m7 (DoS via high iteration count for SCRAM-* auth)
   - GHSA-hm49-wcqc-g2xg (command injection via raw arguments)
   - GHSA-75xq-5h9v-w6px (command injection via unvalidated Symbol inputs)

2. **`fix(layout): remove duplicate <body> + orphan nav from merge artifact`** — PR #81's merge of `main` into `better-accounts` left both the pre-styling navbar and the new-styling navbar in `app/views/layouts/application.html.erb`, producing two `<body>` tags and malformed HTML on every page. Drop the orphaned old block.

3. **`chore(migrations): backfill email_verified_at for pre-existing users`** — new migration sets `email_verified_at = created_at` for any user where it's NULL, so accounts created before the email-verification feature aren't locked out of verification-gated features.

## Test plan

- [x] `bin/rails test` — 163 runs, 457 assertions, 0 failures
- [x] `bin/rubocop` — 114 files, 0 offenses
- [x] `bin/brakeman --no-pager` — no warnings
- [x] `bin/bundler-audit` — no vulnerabilities found
- [x] Local smoke test: all signed-out routes return 200, signed-in home page renders with single `<body>`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)