### PR TITLE
feat(ai): validate image-set prompts and show a 250-character limit

### DIFF
--- a/app/controllers/image_sets_controller.rb
+++ b/app/controllers/image_sets_controller.rb
@@ -360,13 +360,13 @@ class ImageSetsController < ApplicationController
       render :ai_rate_limited, status: :too_many_requests and return
     end
 
-    user_msg = params[:user_message].to_s.strip
-    if user_msg.empty?
-      redirect_to ai_new_image_sets_path, alert: "Type a prompt first." and return
+    validation = AiPromptValidator.validate(params[:user_message])
+    unless validation.ok?
+      redirect_to ai_new_image_sets_path, alert: validation.error and return
     end
 
     prior_conv = parse_conversation(params[:conversation_json])
-    bounded_msg = user_msg.first(8000)
+    bounded_msg = validation.text
 
     # Bump BEFORE enqueue (changed from prior post-success bump).
     # Async architecture needs queue-flood protection, and Gemini bills

--- a/app/javascript/controllers/character_limit_controller.js
+++ b/app/javascript/controllers/character_limit_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Live "n / max" counter for a text field with maxlength.
+export default class extends Controller {
+  static targets = ["input", "counter"]
+  static values = { max: Number }
+
+  connect() {
+    this.boundClearForCache = this.update.bind(this)
+    document.addEventListener("turbo:before-cache", this.boundClearForCache)
+    this.update()
+  }
+
+  disconnect() {
+    document.removeEventListener("turbo:before-cache", this.boundClearForCache)
+  }
+
+  update() {
+    if (!this.hasInputTarget || !this.hasCounterTarget) return
+    const len = this.inputTarget.value.length
+    const max = this.maxValue
+    this.counterTarget.textContent = `${len} / ${max}`
+    this.counterTarget.classList.toggle("text-amber-700", len >= max - 20 && len < max)
+    this.counterTarget.classList.toggle("text-red-600", len >= max)
+    this.counterTarget.classList.toggle("text-forest-700", len < max - 20)
+  }
+}

--- a/app/services/ai_prompt_validator.rb
+++ b/app/services/ai_prompt_validator.rb
@@ -1,0 +1,66 @@
+# Validates user prompts for AI image-set generation before they are
+# stored or sent to Gemini. Keeps input bounded, strips unsafe content,
+# and blocks profanity.
+class AiPromptValidator
+  MAX_LENGTH = 250
+
+  # Control chars except tab / LF / CR.
+  DISALLOWED_CONTROL = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/.freeze
+  # Zero-width and bidi override chars (homograph / smuggling tricks).
+  DISALLOWED_INVISIBLE = /[\u200B-\u200F\u202A-\u202E\u2066-\u2069\uFEFF]/.freeze
+  DISALLOWED_MARKUP = /<[^>]+>|javascript\s*:/i.freeze
+
+  PROFANITY_WORDS = %w[
+    asshole bastard bitch bollocks bullshit cock cunt damn dick
+    fag faggot fuck fucker fucking goddamn hell motherfucker
+    nigger piss pussy shit shitty slut twat wanker whore
+  ].freeze
+
+  PROFANITY_PATTERN = /\b(?:#{PROFANITY_WORDS.map { |w| Regexp.escape(w) }.join("|")})\b/i.freeze
+
+  Result = Struct.new(:ok?, :text, :error, keyword_init: true)
+
+  def self.validate(text)
+    new(text).validate
+  end
+
+  def initialize(text)
+    @text = text.to_s.strip
+  end
+
+  def validate
+    return fail("Type a prompt first.") if @text.empty?
+    return fail("Prompt must be at most #{MAX_LENGTH} characters.") if @text.length > MAX_LENGTH
+    return fail("Prompt contains invalid characters.") if @text.match?(DISALLOWED_CONTROL)
+    return fail("Prompt contains invalid characters.") if @text.match?(DISALLOWED_INVISIBLE)
+    return fail("Prompt cannot contain HTML or script markup.") if @text.match?(DISALLOWED_MARKUP)
+    return fail("Please keep your prompt family-friendly.") if profane?(@text)
+
+    Result.new(ok?: true, text: @text)
+  end
+
+  private
+
+  def fail(message)
+    Result.new(ok?: false, error: message)
+  end
+
+  def profane?(text)
+    normalized = normalize_for_profanity(text)
+    normalized.match?(PROFANITY_PATTERN)
+  end
+
+  # Light leetspeak normalization so obvious obfuscations still match.
+  def normalize_for_profanity(text)
+    text.downcase
+        .tr("@4", "aa")
+        .tr("3", "e")
+        .tr("1!", "ii")
+        .tr("0", "o")
+        .tr("$5", "ss")
+        .tr("7", "t")
+        .gsub(/[^a-z\s]/, " ")
+        .squeeze(" ")
+        .strip
+  end
+end

--- a/app/views/image_sets/_ai_prompt_form.html.erb
+++ b/app/views/image_sets/_ai_prompt_form.html.erb
@@ -15,15 +15,30 @@
     turbo:before-cache so neither the snapshot nor a soft reload
     surfaces stale text. %>
 <%= form_with url: ai_generate_image_sets_path, local: true,
-      data: { controller: "ai-form-loading", action: "submit->ai-form-loading#submit" },
+      data: {
+        controller: "ai-form-loading character-limit",
+        action: "submit->ai-form-loading#submit",
+        character_limit_max_value: AiPromptValidator::MAX_LENGTH
+      },
       html: { autocomplete: "off" },
       class: "space-y-3" do |f| %>
-  <div>
-    <label class="text-sm font-medium text-forest-900">
-      <%= conversation.any? ? "Refine your request" : "Describe your image set" %>
-    </label>
-    <%= text_area_tag :user_message, "", class: "form-input", rows: 3, autocomplete: "off",
-          placeholder: conversation.any? ? "e.g. focus only on Hokkaido, or include extinct ones" : "e.g. waterfalls in Norway" %>
+  <div class="space-y-1.5">
+    <div class="flex items-baseline justify-between gap-3">
+      <label for="user_message" class="text-sm font-medium text-forest-900">
+        <%= conversation.any? ? "Refine your request" : "Describe your image set" %>
+      </label>
+      <span data-character-limit-target="counter"
+            class="text-sm font-medium tabular-nums text-forest-700 shrink-0"
+            aria-live="polite">0 / <%= AiPromptValidator::MAX_LENGTH %></span>
+    </div>
+    <%= text_area_tag :user_message, "", id: "user_message", class: "form-input", rows: 3, autocomplete: "off",
+          maxlength: AiPromptValidator::MAX_LENGTH,
+          placeholder: conversation.any? ? "e.g. focus only on Hokkaido, or include extinct ones" : "e.g. waterfalls in Norway",
+          data: {
+            character_limit_target: "input",
+            action: "input->character-limit#update"
+          } %>
+    <p class="muted text-xs">Keep it family-friendly.</p>
   </div>
   <%= hidden_field_tag :conversation_json, conversation.to_json %>
   <div class="flex justify-end items-center gap-3">

--- a/test/controllers/image_sets_controller_test.rb
+++ b/test/controllers/image_sets_controller_test.rb
@@ -145,6 +145,30 @@ class ImageSetsControllerTest < ActionDispatch::IntegrationTest
     assert_match(/Type a prompt first/i, flash[:alert])
   end
 
+  test "ai_generate rejects prompt over 250 characters" do
+    assert_no_difference("AiGeneration.count") do
+      post ai_generate_image_sets_path, params: { user_message: "a" * 251 }
+    end
+    assert_redirected_to ai_new_image_sets_path
+    assert_match(/250 characters/i, flash[:alert])
+  end
+
+  test "ai_generate rejects profanity in prompt" do
+    assert_no_difference("AiGeneration.count") do
+      post ai_generate_image_sets_path, params: { user_message: "damn volcanoes" }
+    end
+    assert_redirected_to ai_new_image_sets_path
+    assert_match(/family-friendly/i, flash[:alert])
+  end
+
+  test "ai_generate rejects markup in prompt" do
+    assert_no_difference("AiGeneration.count") do
+      post ai_generate_image_sets_path, params: { user_message: "<b>volcanoes</b>" }
+    end
+    assert_redirected_to ai_new_image_sets_path
+    assert_match(/markup/i, flash[:alert])
+  end
+
   test "ai_generate enforces daily rate limit" do
     # Burn the daily quota directly in the AiUsage table — the rate
     # limit is now AR-backed (not cache-backed), so this is enough.

--- a/test/services/ai_prompt_validator_test.rb
+++ b/test/services/ai_prompt_validator_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class AiPromptValidatorTest < ActiveSupport::TestCase
+  test "accepts a normal prompt" do
+    result = AiPromptValidator.validate("  waterfalls in Norway  ")
+    assert result.ok?
+    assert_equal "waterfalls in Norway", result.text
+  end
+
+  test "rejects blank prompt" do
+    result = AiPromptValidator.validate("   ")
+    refute result.ok?
+    assert_match(/Type a prompt first/i, result.error)
+  end
+
+  test "rejects prompts over 250 characters" do
+    result = AiPromptValidator.validate("a" * 251)
+    refute result.ok?
+    assert_match(/250 characters/i, result.error)
+  end
+
+  test "accepts prompt at exactly 250 characters" do
+    result = AiPromptValidator.validate("a" * 250)
+    assert result.ok?
+    assert_equal 250, result.text.length
+  end
+
+  test "rejects control characters" do
+    result = AiPromptValidator.validate("volcanoes\x07 in Japan")
+    refute result.ok?
+    assert_match(/invalid characters/i, result.error)
+  end
+
+  test "rejects invisible unicode smuggling characters" do
+    result = AiPromptValidator.validate("volcanoes\u200Bin Japan")
+    refute result.ok?
+    assert_match(/invalid characters/i, result.error)
+  end
+
+  test "rejects HTML and script markup" do
+    result = AiPromptValidator.validate('<script>alert("x")</script> castles')
+    refute result.ok?
+    assert_match(/markup/i, result.error)
+  end
+
+  test "rejects profanity" do
+    result = AiPromptValidator.validate("fucking volcanoes in Japan")
+    refute result.ok?
+    assert_match(/family-friendly/i, result.error)
+  end
+
+  test "rejects leetspeak profanity" do
+    result = AiPromptValidator.validate("sh1t volcanoes")
+    refute result.ok?
+    assert_match(/family-friendly/i, result.error)
+  end
+end


### PR DESCRIPTION
Reject empty, overly long, profane, or unsafe prompts before enqueueing AI generation. Add server-side validation and a live character counter on the prompt form.