### PR TITLE
Multiplayer

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -1,5 +1,5 @@
 class MatchesController < ApplicationController
-  before_action :set_match, only: %i[ show join leave start destroy ]
+  before_action :set_match, only: %i[ show join leave start destroy state guess ]
 
   # GET /matches/new
   def new
@@ -93,11 +93,87 @@ class MatchesController < ApplicationController
                   alert: "Only the host can start, and only with 1-#{Match::LOBBY_CAPACITY} players in the lobby." and return
     end
 
-    # Round creation + EndRoundJob land in the next commit (round lifecycle).
-    # For now just flip the status so the lobby reflects that the host
-    # locked it in.
-    @match.update!(status: "active", started_at: Time.current)
+    Match.transaction do
+      @match.update!(status: "active", started_at: Time.current)
+      round = MatchStartRound.call(match: @match)
+      unless round
+        # No reachable images in the set — bail out, keep the lobby usable.
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    if @match.match_rounds.empty?
+      redirect_to match_path(@match.code),
+                  alert: "This image set doesn't have enough usable images to start a match." and return
+    end
+
     redirect_to match_path(@match.code), status: :see_other
+  end
+
+  # GET /matches/:code/state.json
+  def state
+    player = @match.match_players.find_by(user_id: Current.user.id)
+    current_round = @match.current_round
+
+    payload = {
+      server_now: Time.current.iso8601(3),
+      match: {
+        code:          @match.code,
+        status:        @match.status,
+        rounds_total:  @match.rounds_total,
+        round_index:   current_round&.index
+      },
+      you: {
+        user_id: Current.user.id,
+        joined:  player.present?,
+        is_host: @match.host?(Current.user)
+      },
+      current_round:     build_current_round_payload(current_round, player),
+      last_round_result: build_last_round_result(current_round),
+      players:           build_players_payload(current_round)
+    }
+
+    render json: payload
+  end
+
+  # POST /matches/:code/guess
+  def guess
+    player = @match.match_players.active.find_by(user_id: Current.user.id)
+    return render json: { error: "not_in_match" }, status: :forbidden unless player
+
+    round = @match.current_round
+    if round.nil? || round.ended?
+      return render json: { error: "no_active_round" }, status: :conflict
+    end
+    if Time.current >= round.deadline_at
+      return render json: { error: "round_expired" }, status: :conflict
+    end
+
+    lat = params[:lat].to_f
+    lng = params[:lng].to_f
+    unless lat.between?(-90, 90) && lng.between?(-180, 180)
+      return render json: { error: "bad_coords" }, status: :unprocessable_entity
+    end
+
+    begin
+      MatchGuess.create!(
+        match_round:  round,
+        match_player: player,
+        latitude:     lat,
+        longitude:    lng
+      )
+    rescue ActiveRecord::RecordNotUnique
+      # Two clicks in the same millisecond — the first one stuck, we're fine.
+    end
+
+    # Early-end: if every active player has now submitted, close the round
+    # immediately instead of waiting for the timer. The job is idempotent
+    # so the lingering perform_later becomes a no-op when it fires.
+    active_count  = @match.match_players.active.count
+    guessed_count = round.match_guesses.count
+    MatchEndRound.call(round: round) if guessed_count >= active_count && active_count.positive?
+
+    render json: { ok: true }
   end
 
   # DELETE /matches/:code
@@ -130,5 +206,60 @@ class MatchesController < ApplicationController
     n = raw.to_i
     n = default if n <= 0
     n.clamp(min, max)
+  end
+
+  # Per-round payload while the round is still live. Critical: NEVER include
+  # the answer coords here, and don't echo other players' guess coords —
+  # those reveal atomically in build_last_round_result once the round ends.
+  def build_current_round_payload(round, player)
+    return nil if round.nil? || round.ended?
+    {
+      index:        round.index,
+      image_url:    helpers.image_src(round.image, width: 1600),
+      image_title:  round.image.title,
+      started_at:   round.started_at.iso8601(3),
+      deadline_at:  round.deadline_at.iso8601(3),
+      my_guess_submitted: player.present? &&
+                          round.match_guesses.exists?(match_player_id: player.id)
+    }
+  end
+
+  # Reveals the most recently *ended* round in full: answer, every player's
+  # pin, per-player score. Polling clients diff this against what they've
+  # already shown to decide when to flip to "round over" UI.
+  def build_last_round_result(round)
+    return nil if round.nil? || !round.ended?
+
+    guesses = round.match_guesses.includes(match_player: :user).map do |g|
+      {
+        user_id:     g.match_player.user_id,
+        username:    g.match_player.user.username,
+        lat:         g.latitude.to_f,
+        lng:         g.longitude.to_f,
+        distance_km: g.distance_km&.to_f,
+        score:       g.score.to_i
+      }
+    end
+
+    {
+      round_index: round.index,
+      answer: { lat: round.answer_latitude.to_f, lng: round.answer_longitude.to_f },
+      guesses: guesses
+    }
+  end
+
+  def build_players_payload(current_round)
+    @match.match_players.includes(:user).order(:joined_at).map do |p|
+      locked_in = current_round && !current_round.ended? &&
+                  current_round.match_guesses.exists?(match_player_id: p.id)
+      {
+        user_id:     p.user_id,
+        username:    p.user.username,
+        avatar_url:  p.user.gravatar_url(size: 80),
+        locked_in:   locked_in,
+        total_score: p.total_score,
+        left:        p.left_at.present?
+      }
+    end
   end
 end

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -1,0 +1,134 @@
+class MatchesController < ApplicationController
+  before_action :set_match, only: %i[ show join leave start destroy ]
+
+  # GET /matches/new
+  def new
+    @image_sets = available_image_sets
+  end
+
+  # POST /matches
+  def create
+    image_set = resolve_image_set
+    unless image_set
+      redirect_to new_match_path, alert: "Pick a valid image set." and return
+    end
+
+    rounds_total      = clamp_int(params[:rounds_total],      default: 5,  min: 1,  max: 20)
+    seconds_per_round = clamp_int(params[:seconds_per_round], default: 60, min: 15, max: 300)
+
+    @match = Match.new(
+      host: Current.user,
+      image_set: image_set,
+      rounds_total: rounds_total,
+      seconds_per_round: seconds_per_round
+    )
+
+    Match.transaction do
+      @match.save!
+      @match.match_players.create!(user: Current.user)
+    end
+
+    redirect_to match_path(@match.code), status: :see_other
+  rescue ActiveRecord::RecordInvalid => e
+    flash.now[:alert] = e.message
+    @image_sets = available_image_sets
+    render :new, status: :unprocessable_entity
+  end
+
+  # GET /matches/:code
+  def show
+    @joined     = @match.joined_by?(Current.user)
+    @is_host    = @match.host?(Current.user)
+    @players    = @match.match_players.includes(:user).order(:joined_at).to_a
+    @at_capacity = @match.at_capacity?
+    @can_start  = @match.startable_by?(Current.user)
+    @share_url  = match_url(@match.code)
+  end
+
+  # POST /matches/:code/join
+  def join
+    if @match.joined_by?(Current.user)
+      redirect_to match_path(@match.code) and return
+    end
+    unless @match.status == "lobby"
+      redirect_to match_path(@match.code), alert: "This match has already started." and return
+    end
+    if @match.at_capacity?
+      redirect_to match_path(@match.code),
+                  alert: "Lobby is full (#{Match::LOBBY_CAPACITY} max)." and return
+    end
+
+    begin
+      @match.match_players.create!(user: Current.user)
+    rescue ActiveRecord::RecordNotUnique
+      # raced another join — already a member, fine
+    end
+
+    redirect_to match_path(@match.code), status: :see_other
+  end
+
+  # POST /matches/:code/leave
+  def leave
+    player = @match.match_players.find_by(user_id: Current.user.id)
+    if player.nil?
+      redirect_to root_path and return
+    end
+
+    # In the lobby, leaving deletes the row so the seat opens up again.
+    # Once the match is active we keep the row and just stamp left_at,
+    # because their scoring history needs to survive on the results page.
+    if @match.status == "lobby"
+      player.destroy!
+    else
+      player.update!(left_at: Time.current)
+    end
+
+    redirect_to root_path, notice: "Left the lobby.", status: :see_other
+  end
+
+  # POST /matches/:code/start
+  def start
+    unless @match.startable_by?(Current.user)
+      redirect_to match_path(@match.code),
+                  alert: "Only the host can start, and only with 1-#{Match::LOBBY_CAPACITY} players in the lobby." and return
+    end
+
+    # Round creation + EndRoundJob land in the next commit (round lifecycle).
+    # For now just flip the status so the lobby reflects that the host
+    # locked it in.
+    @match.update!(status: "active", started_at: Time.current)
+    redirect_to match_path(@match.code), status: :see_other
+  end
+
+  # DELETE /matches/:code
+  def destroy
+    unless @match.host?(Current.user)
+      redirect_to match_path(@match.code), alert: "Only the host can delete the match." and return
+    end
+    @match.destroy!
+    redirect_to root_path, notice: "Match deleted.", status: :see_other
+  end
+
+  private
+
+  def set_match
+    @match = Match.find_by!(code: params[:code])
+  end
+
+  def available_image_sets
+    ImageSet.visible_to(Current.user).order(:name)
+  end
+
+  def resolve_image_set
+    return ImageSet.default if params[:image_set_id].blank?
+    set = ImageSet.find_by(id: params[:image_set_id])
+    return nil unless set&.playable_by?(Current.user)
+    set
+  end
+
+  def clamp_int(raw, default:, min:, max:)
+    n = raw.to_i
+    n = default if n <= 0
+    n.clamp(min, max)
+  end
+end

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -267,6 +267,7 @@ class MatchesController < ApplicationController
   end
 
   def build_players_payload(current_round)
+    host_id = @match.host_id
     @match.match_players.includes(:user).order(:joined_at).map do |p|
       locked_in = current_round && !current_round.ended? &&
                   current_round.match_guesses.exists?(match_player_id: p.id)
@@ -274,6 +275,7 @@ class MatchesController < ApplicationController
         user_id:     p.user_id,
         username:    p.user.username,
         avatar_url:  p.user.gravatar_url(size: 80),
+        is_host:     p.user_id == host_id,
         locked_in:   locked_in,
         total_score: p.total_score,
         left:        p.left_at.present?

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -1,5 +1,5 @@
 class MatchesController < ApplicationController
-  before_action :set_match, only: %i[ show join leave start destroy state guess ]
+  before_action :set_match, only: %i[ show join leave start destroy state guess results ]
 
   # GET /matches/new
   def new
@@ -174,6 +174,24 @@ class MatchesController < ApplicationController
     MatchEndRound.call(round: round) if guessed_count >= active_count && active_count.positive?
 
     render json: { ok: true }
+  end
+
+  # GET /matches/:code/results
+  def results
+    @rounds = @match.match_rounds
+                    .includes(:image, match_guesses: { match_player: :user })
+                    .order(:index)
+    @players = @match.match_players.includes(:user).to_a
+
+    # Final standings: rank by total_score desc, then by earliest joined_at
+    # to make ties stable (whoever sat down first ranks higher).
+    @standings = @players.sort_by { |p| [ -p.total_score.to_i, p.joined_at.to_i ] }
+
+    # Per-round breakdown keyed by [round_id, player_id] so the view can
+    # render an N×R table without per-cell DB hits.
+    @guess_index = @match.match_guesses.each_with_object({}) do |g, h|
+      h[[ g.match_round_id, g.match_player_id ]] = g
+    end
   end
 
   # DELETE /matches/:code

--- a/app/javascript/controllers/match_lobby_poll_controller.js
+++ b/app/javascript/controllers/match_lobby_poll_controller.js
@@ -1,0 +1,71 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Polls /matches/:code/state.json while the match is still in the lobby:
+// re-renders the player list as people join/leave, and reloads the page
+// once the host flips status to "active" (or anything non-lobby) so the
+// server-rendered play view takes over.
+export default class extends Controller {
+  static values = {
+    stateUrl:   String,
+    intervalMs: { type: Number, default: 2000 }
+  }
+  static targets = ["playerList", "playerCount"]
+
+  connect() {
+    this.tick()
+    this.timer = setInterval(() => this.tick(), this.intervalMsValue)
+  }
+
+  disconnect() {
+    clearInterval(this.timer)
+  }
+
+  async tick() {
+    try {
+      const res = await fetch(this.stateUrlValue, {
+        headers: { "Accept": "application/json" },
+        credentials: "same-origin"
+      })
+      if (!res.ok) return
+      const state = await res.json()
+
+      if (state.match.status !== "lobby") {
+        // Host started (or match was deleted). Reload so the play / finished
+        // view renders with all the server-side state we don't have here.
+        clearInterval(this.timer)
+        window.location.reload()
+        return
+      }
+
+      this.renderPlayers(state)
+    } catch (_) {
+      // network blip — next tick tries again
+    }
+  }
+
+  renderPlayers(state) {
+    if (this.hasPlayerCountTarget) {
+      this.playerCountTarget.textContent = `${state.players.length}/100`
+    }
+    if (!this.hasPlayerListTarget) return
+
+    const youId = state.you.user_id
+    this.playerListTarget.innerHTML = state.players.map(p => `
+      <div class="flex items-center gap-4 px-5 py-3.5 bg-white">
+        <span class="flex items-center gap-2 flex-1 min-w-0">
+          <img src="${this.esc(p.avatar_url)}" alt=""
+               class="w-7 h-7 rounded-full shrink-0" width="40" height="40">
+          <span class="font-medium text-forest-900 truncate">${this.esc(p.username)}</span>
+          ${p.is_host ? '<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-forest-100 text-forest-700">Host</span>' : ''}
+          ${p.user_id === youId ? '<span class="text-xs text-gray-400">(you)</span>' : ''}
+        </span>
+      </div>
+    `).join("")
+  }
+
+  esc(s) {
+    return String(s ?? "").replace(/[&<>"']/g, c => ({
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+    }[c]))
+  }
+}

--- a/app/javascript/controllers/match_poll_controller.js
+++ b/app/javascript/controllers/match_poll_controller.js
@@ -1,0 +1,242 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Drives a multiplayer match page over plain HTTP polling. Asks the server
+// for /matches/:code/state.json every `intervalMs`, diffs against what's
+// already on screen, and pokes the embedded guess-map controller for
+// per-round pin / answer / reveal updates.
+//
+// The map is the existing single-player Stimulus controller — multiplayer
+// only adds this sibling controller on top, no fork of map code.
+export default class extends Controller {
+  static values = {
+    stateUrl:   String,
+    guessUrl:   String,
+    intervalMs: { type: Number, default: 2000 }
+  }
+  static targets = [
+    "image", "imageTitle", "roundLabel", "timer", "status",
+    "scoreboard", "reveal", "guessHint", "lockedBadge", "finished"
+  ]
+
+  connect() {
+    this.currentRoundIndex   = null
+    this.revealedRoundIndex  = null
+    this.guessInFlight       = false
+    this.serverOffsetMs      = 0
+    this.deadlineMs          = null
+
+    this.boundPinned = (e) => this.onPinned(e)
+    this.element.addEventListener("guess-map:pinned", this.boundPinned)
+
+    this.tick()
+    this.pollTimer = setInterval(() => this.tick(), this.intervalMsValue)
+    this.countdownTimer = setInterval(() => this.updateCountdown(), 250)
+  }
+
+  disconnect() {
+    clearInterval(this.pollTimer)
+    clearInterval(this.countdownTimer)
+    this.element.removeEventListener("guess-map:pinned", this.boundPinned)
+  }
+
+  async tick() {
+    try {
+      const res = await fetch(this.stateUrlValue, {
+        headers: { "Accept": "application/json" },
+        credentials: "same-origin"
+      })
+      if (!res.ok) return
+      const state = await res.json()
+      this.applyState(state)
+    } catch (_) {
+      // network blip — next tick will try again
+    }
+  }
+
+  applyState(state) {
+    this.state = state
+    this.serverOffsetMs = Date.now() - Date.parse(state.server_now)
+
+    if (this.hasStatusTarget) {
+      this.statusTarget.textContent = state.match.status
+    }
+
+    this.applyRound(state)
+    this.applyReveal(state)
+    this.applyScoreboard(state)
+    this.applyFinished(state)
+  }
+
+  applyRound(state) {
+    const cr = state.current_round
+    if (!cr) return
+
+    if (cr.index !== this.currentRoundIndex) {
+      // New round — flip the visible artifacts and reset the map so the
+      // previous reveal markers / answer line are gone before the player
+      // can drop a new pin.
+      this.currentRoundIndex = cr.index
+      this.guessInFlight = false
+
+      const map = this.mapController
+      if (map) {
+        map.reset()
+      }
+
+      if (this.hasImageTarget)      this.imageTarget.src = cr.image_url
+      if (this.hasImageTitleTarget) this.imageTitleTarget.textContent = cr.image_title || ""
+      if (this.hasRoundLabelTarget) {
+        this.roundLabelTarget.textContent = `Round ${cr.index} / ${state.match.rounds_total}`
+      }
+      if (this.hasGuessHintTarget) {
+        this.guessHintTarget.textContent = "Click the map to drop your pin."
+        this.guessHintTarget.classList.remove("hidden")
+      }
+      if (this.hasLockedBadgeTarget) this.lockedBadgeTarget.classList.add("hidden")
+
+      this.deadlineMs = Date.parse(cr.deadline_at)
+    }
+
+    if (cr.my_guess_submitted) {
+      this.markGuessAccepted()
+    }
+  }
+
+  applyReveal(state) {
+    const r = state.last_round_result
+    if (!r) return
+    if (r.round_index === this.revealedRoundIndex) return
+    this.revealedRoundIndex = r.round_index
+
+    const map = this.mapController
+    if (map) {
+      map.lock()
+      map.showAnswer(r.answer.lat, r.answer.lng)
+      const others = r.guesses
+        .filter(g => g.user_id !== state.you.user_id)
+        .map(g => ({ username: g.username, latitude: g.lat, longitude: g.lng }))
+      if (others.length) map.showOtherGuesses(others, r.answer.lat, r.answer.lng)
+    }
+
+    if (this.hasRevealTarget) {
+      const sorted = [...r.guesses].sort((a, b) => (b.score || 0) - (a.score || 0))
+      const rows = sorted.map(g => `
+        <div class="flex items-center justify-between text-sm">
+          <span class="truncate">${this.escape(g.username)}</span>
+          <span class="text-xs text-gray-500 ml-2">${this.formatKm(g.distance_km)}</span>
+          <span class="ml-3 font-semibold text-amber-600 tabular-nums">${g.score || 0}</span>
+        </div>
+      `).join("")
+      this.revealTarget.innerHTML = `
+        <div class="font-semibold mb-1.5">Round ${r.round_index} reveal</div>
+        ${rows || '<div class="text-xs text-gray-400">No guesses submitted.</div>'}
+      `
+      this.revealTarget.classList.remove("hidden")
+    }
+  }
+
+  applyScoreboard(state) {
+    if (!this.hasScoreboardTarget) return
+    const players = [...state.players].sort((a, b) => b.total_score - a.total_score)
+    this.scoreboardTarget.innerHTML = players.map((p, i) => `
+      <div class="flex items-center gap-3 px-3 py-2 ${p.left ? 'opacity-50' : ''}">
+        <span class="w-5 text-right text-sm text-gray-400">${i + 1}</span>
+        <img src="${this.escape(p.avatar_url)}" class="w-6 h-6 rounded-full" alt="" />
+        <span class="flex-1 truncate text-sm text-forest-900">
+          ${this.escape(p.username)}
+          ${p.locked_in ? '<span class="ml-1 text-xs text-emerald-600">✓</span>' : ''}
+        </span>
+        <span class="font-semibold text-amber-500 tabular-nums">${p.total_score}</span>
+      </div>
+    `).join("")
+  }
+
+  applyFinished(state) {
+    if (state.match.status !== "finished") return
+    if (this.hasFinishedTarget) this.finishedTarget.classList.remove("hidden")
+    if (this.hasGuessHintTarget) this.guessHintTarget.classList.add("hidden")
+    // Stop polling — nothing else will change.
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer)
+      this.pollTimer = null
+    }
+  }
+
+  updateCountdown() {
+    if (!this.deadlineMs || !this.hasTimerTarget) return
+    if (this.state?.current_round == null) {
+      this.timerTarget.textContent = ""
+      return
+    }
+    const serverNowMs = Date.now() - this.serverOffsetMs
+    const remainingMs = this.deadlineMs - serverNowMs
+    const seconds = Math.max(0, Math.ceil(remainingMs / 1000))
+    this.timerTarget.textContent = `${seconds}s`
+    if (seconds <= 5) {
+      this.timerTarget.classList.add("text-red-600")
+    } else {
+      this.timerTarget.classList.remove("text-red-600")
+    }
+  }
+
+  onPinned(e) {
+    if (this.guessInFlight) return
+    if (this.revealedRoundIndex === this.currentRoundIndex) return  // round already ended
+    const { lat, lng } = e.detail
+    this.sendGuess(lat, lng)
+  }
+
+  async sendGuess(lat, lng) {
+    this.guessInFlight = true
+    try {
+      const csrf = document.querySelector('meta[name="csrf-token"]')?.content || ""
+      const res = await fetch(this.guessUrlValue, {
+        method: "POST",
+        credentials: "same-origin",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept": "application/json",
+          "X-CSRF-Token": csrf
+        },
+        body: JSON.stringify({ lat, lng })
+      })
+      if (res.ok) {
+        this.markGuessAccepted()
+        this.tick()  // refresh state so other players see us locked in faster
+      } else {
+        // 409 (round ended/expired) or 422 (bad coords) — let the next poll
+        // resync; clear the in-flight flag so the player can try a different
+        // pin if the round is still open.
+        this.guessInFlight = false
+      }
+    } catch (_) {
+      this.guessInFlight = false
+    }
+  }
+
+  markGuessAccepted() {
+    this.guessInFlight = true
+    this.mapController?.lock()
+    if (this.hasGuessHintTarget)   this.guessHintTarget.classList.add("hidden")
+    if (this.hasLockedBadgeTarget) this.lockedBadgeTarget.classList.remove("hidden")
+  }
+
+  get mapController() {
+    const el = this.element.querySelector("[data-controller~='guess-map']")
+    if (!el) return null
+    return this.application.getControllerForElementAndIdentifier(el, "guess-map")
+  }
+
+  escape(s) {
+    return String(s ?? "").replace(/[&<>"']/g, c => ({
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+    }[c]))
+  }
+
+  formatKm(km) {
+    if (km == null) return ""
+    if (km < 1)   return `${Math.round(km * 1000)} m`
+    if (km < 10)  return `${km.toFixed(1)} km`
+    return `${Math.round(km).toLocaleString()} km`
+  }
+}

--- a/app/javascript/controllers/match_poll_controller.js
+++ b/app/javascript/controllers/match_poll_controller.js
@@ -11,6 +11,7 @@ export default class extends Controller {
   static values = {
     stateUrl:   String,
     guessUrl:   String,
+    resultsUrl: String,
     intervalMs: { type: Number, default: 2000 }
   }
   static targets = [

--- a/app/jobs/end_match_round_job.rb
+++ b/app/jobs/end_match_round_job.rb
@@ -1,0 +1,9 @@
+class EndMatchRoundJob < ApplicationJob
+  queue_as :default
+
+  def perform(round_id)
+    round = MatchRound.find_by(id: round_id)
+    return unless round
+    MatchEndRound.call(round: round)
+  end
+end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -1,0 +1,80 @@
+class Match < ApplicationRecord
+  # Cap enforced by the host start gate and the lobby join path. 100 is the
+  # product call: small enough to keep round payloads under a few KB even
+  # with everyone guessing simultaneously, large enough that classroom /
+  # event use cases fit without partitioning.
+  LOBBY_CAPACITY = 100
+
+  STATUSES = %w[lobby active finished].freeze
+
+  # Crockford-ish: ambiguous chars (0/O/1/I) removed so people can read the
+  # code off a screen-share. 6 chars over a 32-symbol alphabet ≈ 1 billion
+  # possibilities, plenty for the active-match table.
+  CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789".chars.freeze
+  CODE_LENGTH = 6
+
+  belongs_to :host, class_name: "User"
+  belongs_to :image_set
+  has_many :match_players, dependent: :destroy
+  has_many :players, through: :match_players, source: :user
+  has_many :match_rounds, -> { order(:index) }, dependent: :destroy
+  has_many :match_guesses, through: :match_rounds
+
+  validates :code, presence: true, uniqueness: true
+  validates :status, inclusion: { in: STATUSES }
+  validates :rounds_total,      numericality: { only_integer: true, greater_than: 0 }
+  validates :seconds_per_round, numericality: { only_integer: true, greater_than: 0 }
+
+  before_validation :ensure_code
+
+  scope :lobby,    -> { where(status: "lobby") }
+  scope :active,   -> { where(status: "active") }
+  scope :finished, -> { where(status: "finished") }
+
+  def to_param
+    code
+  end
+
+  def host?(user)
+    user && host_id == user.id
+  end
+
+  def joined_by?(user)
+    user && match_players.exists?(user_id: user.id)
+  end
+
+  # In the lobby AND (already joined OR under capacity).
+  def joinable_by?(user)
+    return false unless user
+    return true  if joined_by?(user)
+    status == "lobby" && !at_capacity?
+  end
+
+  def startable_by?(user)
+    host?(user) &&
+      status == "lobby" &&
+      match_players.count.between?(1, LOBBY_CAPACITY)
+  end
+
+  def at_capacity?
+    match_players.count >= LOBBY_CAPACITY
+  end
+
+  def current_round
+    match_rounds.last
+  end
+
+  def self.generate_unique_code
+    20.times do
+      candidate = Array.new(CODE_LENGTH) { CODE_ALPHABET.sample }.join
+      return candidate unless exists?(code: candidate)
+    end
+    raise "Could not generate unique match code after 20 attempts"
+  end
+
+  private
+
+  def ensure_code
+    self.code = self.class.generate_unique_code if code.blank?
+  end
+end

--- a/app/models/match_guess.rb
+++ b/app/models/match_guess.rb
@@ -1,0 +1,14 @@
+class MatchGuess < ApplicationRecord
+  belongs_to :match_round
+  belongs_to :match_player
+
+  validates :match_player_id, uniqueness: { scope: :match_round_id }
+
+  before_validation :ensure_submitted_at
+
+  private
+
+  def ensure_submitted_at
+    self.submitted_at ||= Time.current
+  end
+end

--- a/app/models/match_player.rb
+++ b/app/models/match_player.rb
@@ -1,0 +1,17 @@
+class MatchPlayer < ApplicationRecord
+  belongs_to :match
+  belongs_to :user
+  has_many :match_guesses, dependent: :destroy
+
+  validates :user_id, uniqueness: { scope: :match_id }
+
+  before_validation :ensure_joined_at
+
+  scope :active, -> { where(left_at: nil, forfeited_at: nil) }
+
+  private
+
+  def ensure_joined_at
+    self.joined_at ||= Time.current
+  end
+end

--- a/app/models/match_round.rb
+++ b/app/models/match_round.rb
@@ -1,0 +1,15 @@
+class MatchRound < ApplicationRecord
+  belongs_to :match
+  belongs_to :image
+  has_many :match_guesses, dependent: :destroy
+
+  validates :index, presence: true, uniqueness: { scope: :match_id }
+
+  def ended?
+    ended_at.present?
+  end
+
+  def expired?
+    deadline_at && Time.current >= deadline_at
+  end
+end

--- a/app/services/match_end_round.rb
+++ b/app/services/match_end_round.rb
@@ -1,0 +1,40 @@
+# Ends a round: marks it ended, scores every guess against the answer,
+# updates each player's running total, and either kicks off the next
+# round or finishes the match.
+#
+# Idempotent. Both the timer job and the "everyone guessed" early-end
+# path call this — whichever fires first wins, the other becomes a
+# cheap DB lookup. The transactional row lock prevents two concurrent
+# calls from double-scoring.
+class MatchEndRound
+  def self.call(round:)
+    return if round.ended_at.present?
+
+    MatchRound.transaction do
+      locked = MatchRound.lock.find(round.id)
+      return if locked.ended_at.present?
+      locked.update!(ended_at: Time.current)
+      score_guesses_for(locked)
+    end
+
+    match = round.match
+    if match.match_rounds.count >= match.rounds_total
+      match.update!(status: "finished", finished_at: Time.current)
+    else
+      MatchStartRound.call(match: match)
+    end
+  end
+
+  def self.score_guesses_for(round)
+    round.match_guesses.find_each do |g|
+      dist_km = Game.haversine_km(
+        g.latitude.to_f, g.longitude.to_f,
+        round.answer_latitude.to_f, round.answer_longitude.to_f
+      )
+      score = Game.geoguessr_round_score(dist_km)
+      g.update_columns(distance_km: dist_km, score: score)
+      MatchPlayer.where(id: g.match_player_id)
+                 .update_all([ "total_score = total_score + ?", score.to_i ])
+    end
+  end
+end

--- a/app/services/match_start_round.rb
+++ b/app/services/match_start_round.rb
@@ -1,0 +1,34 @@
+# Starts the next round of a Match. Picks a random image from the match's
+# set that hasn't been used yet, stamps the deadline, and schedules the
+# job that closes the round when the timer runs out.
+#
+# Returns the MatchRound, or nil if the set is exhausted (caller should
+# finish the match in that case).
+class MatchStartRound
+  def self.call(match:)
+    next_index = (match.match_rounds.maximum(:index) || 0) + 1
+    return nil if next_index > match.rounds_total
+
+    used_image_ids = match.match_rounds.pluck(:image_id)
+    item = match.image_set.image_set_items
+      .with_usable_coords
+      .where.not(image_id: used_image_ids)
+      .order(Arel.sql("RANDOM()"))
+      .first
+
+    return nil unless item
+
+    now = Time.current
+    round = match.match_rounds.create!(
+      index: next_index,
+      image_id: item.image_id,
+      answer_latitude:  item.answer_lat,
+      answer_longitude: item.answer_lng,
+      started_at:  now,
+      deadline_at: now + match.seconds_per_round.seconds
+    )
+
+    EndMatchRoundJob.set(wait: match.seconds_per_round.seconds).perform_later(round.id)
+    round
+  end
+end

--- a/app/views/home/start.html.erb
+++ b/app/views/home/start.html.erb
@@ -22,10 +22,11 @@
     </div>
 
     <%# Quick access cards %>
-    <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
+    <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
       <% [
         { label: "My Games",   sub: "View past results",    path: games_path },
         { label: "Challenges", sub: "Play against friends",  path: challenges_path },
+        { label: "Multiplayer", sub: "Real-time lobby, share a link", path: new_match_path },
         { label: "Practice",   sub: "Quick rounds + saved mistakes", path: practice_path },
         { label: "Image Sets", sub: "Browse & manage sets", path: image_sets_path },
         {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,6 +42,7 @@
               <%= link_to "Games",       games_path,      class: "text-sm text-forest-700 hover:text-forest-900 font-medium transition-colors" %>
               <%= link_to "Image Sets",  image_sets_path, class: "text-sm text-forest-700 hover:text-forest-900 font-medium transition-colors" %>
               <%= link_to "Challenges",  challenges_path, class: "text-sm text-forest-700 hover:text-forest-900 font-medium transition-colors" %>
+              <%= link_to "Multiplayer", new_match_path, class: "text-sm text-forest-700 hover:text-forest-900 font-medium transition-colors" %>
             <% end %>
           </div>
         </div>
@@ -92,6 +93,7 @@
             <%= link_to "Leaderboard", leaderboard_games_path, data: { action: "mobile-menu#close" }, class: "block py-2.5 text-sm font-medium text-forest-800 hover:text-forest-600 transition-colors" %>
             <%= link_to "Image Sets", image_sets_path, data: { action: "mobile-menu#close" }, class: "block py-2.5 text-sm font-medium text-forest-800 hover:text-forest-600 transition-colors" %>
             <%= link_to "Challenges", challenges_path, data: { action: "mobile-menu#close" }, class: "block py-2.5 text-sm font-medium text-forest-800 hover:text-forest-600 transition-colors" %>
+            <%= link_to "Multiplayer", new_match_path,  data: { action: "mobile-menu#close" }, class: "block py-2.5 text-sm font-medium text-forest-800 hover:text-forest-600 transition-colors" %>
             <%= link_to "Practice",   practice_path,   data: { action: "mobile-menu#close" }, class: "block py-2.5 text-sm font-medium text-forest-800 hover:text-forest-600 transition-colors" %>
             <%= link_to "How scoring works", scoring_path, data: { action: "mobile-menu#close" }, class: "block py-2.5 text-sm font-medium text-forest-800 hover:text-forest-600 transition-colors" %>
             <div class="pt-3 border-t border-forest-100 flex items-center justify-between">

--- a/app/views/matches/_lobby.html.erb
+++ b/app/views/matches/_lobby.html.erb
@@ -1,0 +1,53 @@
+<%# Lobby: share link, join CTA / host start CTA, player list. %>
+
+<div class="card px-5 py-4 space-y-2 border-forest-200">
+  <p class="text-sm font-semibold text-forest-800">Invite link</p>
+  <div class="flex items-center gap-2">
+    <code class="flex-1 text-xs bg-forest-50 border border-forest-200 rounded-lg px-3 py-2.5 text-forest-800 truncate select-all font-mono"><%= @share_url %></code>
+    <button type="button"
+            onclick="navigator.clipboard.writeText('<%= @share_url %>').then(() => { this.textContent = 'Copied!'; setTimeout(() => this.textContent = 'Copy', 1500) })"
+            class="btn-secondary text-sm py-2 shrink-0">Copy</button>
+  </div>
+  <p class="muted text-xs">Anyone with the link can join up to <%= Match::LOBBY_CAPACITY %> players.</p>
+</div>
+
+<% if !@joined && @at_capacity %>
+  <div class="card px-5 py-4 text-center text-sm text-amber-700 bg-amber-50 border-amber-200">
+    Lobby is full (<%= Match::LOBBY_CAPACITY %> players). Ask the host to start.
+  </div>
+<% elsif !@joined %>
+  <%= button_to "Join lobby", join_match_path(@match.code), method: :post,
+        class: "btn-primary w-full py-3 text-base" %>
+<% elsif @is_host %>
+  <%= button_to "Start match (#{pluralize(@players.size, "player")})",
+        start_match_path(@match.code), method: :post,
+        class: "btn-primary w-full py-3 text-base",
+        disabled: !@can_start %>
+<% else %>
+  <div class="card px-5 py-4 text-center text-sm text-forest-700">
+    Waiting for <strong><%= @match.host.username %></strong> to start the match…
+  </div>
+<% end %>
+
+<section class="space-y-3">
+  <h2 class="heading-section">
+    Players (<%= @players.size %>/<%= Match::LOBBY_CAPACITY %>)
+  </h2>
+  <div class="card overflow-hidden divide-y divide-forest-50">
+    <% @players.each do |player| %>
+      <div class="flex items-center gap-4 px-5 py-3.5 bg-white">
+        <span class="flex items-center gap-2 flex-1 min-w-0">
+          <img src="<%= player.user.gravatar_url(size: 40) %>" alt=""
+               class="w-7 h-7 rounded-full shrink-0" width="40" height="40">
+          <span class="font-medium text-forest-900 truncate"><%= player.user.username %></span>
+          <% if @match.host_id == player.user_id %>
+            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-forest-100 text-forest-700">Host</span>
+          <% end %>
+          <% if player.user_id == Current.user.id %>
+            <span class="text-xs text-gray-400">(you)</span>
+          <% end %>
+        </span>
+      </div>
+    <% end %>
+  </div>
+</section>

--- a/app/views/matches/_lobby.html.erb
+++ b/app/views/matches/_lobby.html.erb
@@ -1,4 +1,12 @@
-<%# Lobby: share link, join CTA / host start CTA, player list. %>
+<%# Lobby: share link, join CTA / host start CTA, player list.
+    The wrapping div mounts match-lobby-poll, which polls state.json so
+    joins appear without a refresh and a host start auto-reloads the page
+    onto the play view. %>
+
+<div data-controller="match-lobby-poll"
+     data-match-lobby-poll-state-url-value="<%= state_match_path(@match.code, format: :json) %>"
+     data-match-lobby-poll-interval-ms-value="2000"
+     class="space-y-6">
 
 <div class="card px-5 py-4 space-y-2 border-forest-200">
   <p class="text-sm font-semibold text-forest-800">Invite link</p>
@@ -31,9 +39,10 @@
 
 <section class="space-y-3">
   <h2 class="heading-section">
-    Players (<%= @players.size %>/<%= Match::LOBBY_CAPACITY %>)
+    Players (<span data-match-lobby-poll-target="playerCount"><%= @players.size %>/<%= Match::LOBBY_CAPACITY %></span>)
   </h2>
-  <div class="card overflow-hidden divide-y divide-forest-50">
+  <div class="card overflow-hidden divide-y divide-forest-50"
+       data-match-lobby-poll-target="playerList">
     <% @players.each do |player| %>
       <div class="flex items-center gap-4 px-5 py-3.5 bg-white">
         <span class="flex items-center gap-2 flex-1 min-w-0">
@@ -51,3 +60,6 @@
     <% end %>
   </div>
 </section>
+
+</div>
+

--- a/app/views/matches/new.html.erb
+++ b/app/views/matches/new.html.erb
@@ -1,0 +1,54 @@
+<% content_for :title, "New multiplayer match" %>
+
+<div class="min-h-[calc(100vh-12rem)] flex items-center justify-center py-12">
+  <div class="w-full max-w-sm space-y-6">
+    <div class="text-center space-y-1">
+      <p class="eyebrow">Multiplayer</p>
+      <h1 class="heading-page">Create a match</h1>
+      <p class="muted">You'll get a share link. Up to <%= Match::LOBBY_CAPACITY %> players per lobby.</p>
+    </div>
+
+    <div class="card p-8 space-y-5">
+      <%= form_with url: matches_path, method: :post do |f| %>
+        <div>
+          <%= f.label :image_set_id, "Image set", class: "block text-sm font-medium text-forest-800" %>
+          <% default_set = @image_sets.first %>
+          <% default_label = default_set ? default_set.name + (default_set.is_system_default? ? " (default)" : "") : "Select…" %>
+          <div data-controller="dropdown" class="relative mt-2">
+            <%= f.hidden_field :image_set_id, value: default_set&.id, data: { dropdown_target: "input" } %>
+            <button type="button" data-action="dropdown#toggle"
+                    class="flex items-center justify-between w-full gap-2 rounded-lg border border-forest-200 px-3.5 py-2.5 text-sm bg-white text-forest-800 hover:bg-forest-50 transition-colors">
+              <span data-dropdown-target="label"><%= default_label %></span>
+              <svg class="w-4 h-4 text-forest-500 shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"/></svg>
+            </button>
+            <div data-dropdown-target="menu" class="hidden absolute left-0 right-0 top-full mt-1 z-30 bg-white rounded-xl border border-forest-200 shadow-lg overflow-hidden max-h-56 overflow-y-auto">
+              <% @image_sets.each do |s| %>
+                <% lbl = s.name + (s.is_system_default? ? " (default)" : "") %>
+                <button type="button" data-action="dropdown#pick"
+                        data-value="<%= s.id %>" data-label="<%= lbl %>"
+                        class="w-full text-left px-4 py-2.5 text-sm text-forest-800 hover:bg-forest-50 transition-colors">
+                  <%= lbl %>
+                </button>
+              <% end %>
+            </div>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-2 gap-3">
+          <div>
+            <%= label_tag :rounds_total, "Rounds", class: "block text-sm font-medium text-forest-800" %>
+            <%= number_field_tag :rounds_total, 5, min: 1, max: 20,
+                  class: "mt-2 w-full rounded-lg border border-forest-200 px-3 py-2 text-sm" %>
+          </div>
+          <div>
+            <%= label_tag :seconds_per_round, "Seconds / round", class: "block text-sm font-medium text-forest-800" %>
+            <%= number_field_tag :seconds_per_round, 60, min: 15, max: 300,
+                  class: "mt-2 w-full rounded-lg border border-forest-200 px-3 py-2 text-sm" %>
+          </div>
+        </div>
+
+        <%= f.submit "Create match", class: "btn-primary w-full" %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/matches/results.html.erb
+++ b/app/views/matches/results.html.erb
@@ -1,0 +1,121 @@
+<% content_for :title, "Results · #{@match.code}" %>
+
+<div class="w-full max-w-4xl mx-auto space-y-6 py-6">
+
+  <div class="space-y-1">
+    <p class="eyebrow">Multiplayer · Finished</p>
+    <h1 class="heading-page"><%= @match.image_set.name %></h1>
+    <p class="muted">
+      Host: <%= @match.host.username %> ·
+      <%= pluralize(@match.rounds_total, "round") %> ·
+      <%= @match.seconds_per_round %>s per round
+    </p>
+  </div>
+
+  <%# === Final standings === %>
+  <section class="space-y-3">
+    <h2 class="heading-section">Final standings</h2>
+    <div class="card overflow-hidden divide-y divide-forest-50">
+      <% @standings.each_with_index do |player, idx| %>
+        <% rank_pill =
+             case idx
+             when 0 then "bg-amber-100 text-amber-700"
+             when 1 then "bg-gray-100 text-gray-700"
+             when 2 then "bg-orange-100 text-orange-700"
+             else        "bg-forest-50 text-forest-600"
+             end %>
+        <div class="flex items-center gap-4 px-5 py-3.5 bg-white <%= 'opacity-50' if player.left_at.present? %>">
+          <span class="inline-flex items-center justify-center w-7 h-7 rounded-full text-xs font-bold <%= rank_pill %>">
+            <%= idx + 1 %>
+          </span>
+          <img src="<%= player.user.gravatar_url(size: 40) %>" alt=""
+               class="w-7 h-7 rounded-full shrink-0" width="40" height="40">
+          <span class="flex-1 min-w-0">
+            <span class="font-medium text-forest-900 truncate"><%= player.user.username %></span>
+            <% if @match.host_id == player.user_id %>
+              <span class="ml-1 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-forest-100 text-forest-700">Host</span>
+            <% end %>
+            <% if player.user_id == Current.user.id %>
+              <span class="ml-1 text-xs text-gray-400">(you)</span>
+            <% end %>
+            <% if player.left_at.present? %>
+              <span class="ml-1 text-xs text-gray-400">left</span>
+            <% end %>
+          </span>
+          <span class="font-bold text-amber-500 font-display tabular-nums">
+            <%= number_with_delimiter(player.total_score.to_i) %>
+          </span>
+        </div>
+      <% end %>
+    </div>
+  </section>
+
+  <%# === Per-round breakdown === %>
+  <% if @rounds.any? %>
+    <section class="space-y-3">
+      <h2 class="heading-section">Round-by-round</h2>
+      <div class="card overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead class="bg-forest-50 text-forest-700">
+            <tr>
+              <th class="text-left px-4 py-2 font-semibold">Round</th>
+              <% @standings.each do |player| %>
+                <th class="text-right px-3 py-2 font-semibold whitespace-nowrap">
+                  <%= player.user.username %>
+                </th>
+              <% end %>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-forest-50">
+            <% @rounds.each do |round| %>
+              <tr class="bg-white">
+                <td class="px-4 py-2 align-top">
+                  <div class="font-medium text-forest-900">#<%= round.index %></div>
+                  <div class="text-xs text-gray-500 truncate max-w-[16rem]">
+                    <%= round.image.title %>
+                  </div>
+                </td>
+                <% @standings.each do |player| %>
+                  <% g = @guess_index[[ round.id, player.id ]] %>
+                  <td class="px-3 py-2 text-right tabular-nums">
+                    <% if g %>
+                      <div class="font-semibold text-amber-600"><%= g.score.to_i %></div>
+                      <div class="text-xs text-gray-400">
+                        <% if g.distance_km %>
+                          <% km = g.distance_km.to_f %>
+                          <% if km < 1 %>
+                            <%= (km * 1000).round %> m
+                          <% elsif km < 10 %>
+                            <%= km.round(1) %> km
+                          <% else %>
+                            <%= number_with_delimiter(km.round) %> km
+                          <% end %>
+                        <% end %>
+                      </div>
+                    <% else %>
+                      <span class="text-gray-300">—</span>
+                    <% end %>
+                  </td>
+                <% end %>
+              </tr>
+            <% end %>
+            <tr class="bg-forest-50 font-bold">
+              <td class="px-4 py-2 text-left">Total</td>
+              <% @standings.each do |player| %>
+                <td class="px-3 py-2 text-right text-amber-600 tabular-nums">
+                  <%= number_with_delimiter(player.total_score.to_i) %>
+                </td>
+              <% end %>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  <% end %>
+
+  <div class="flex items-center justify-between pt-2">
+    <%= link_to "Home", root_path, class: "btn-ghost" %>
+    <%= link_to "Match overview", match_path(@match.code), class: "btn-secondary" %>
+  </div>
+
+</div>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -1,0 +1,100 @@
+<% content_for :title, "Lobby #{@match.code}" %>
+
+<div class="w-full max-w-xl mx-auto space-y-6 py-6">
+
+  <div class="space-y-1">
+    <p class="eyebrow">Multiplayer · <%= @match.status.titleize %></p>
+    <h1 class="heading-page">
+      <%= @match.image_set.name %>
+    </h1>
+    <p class="muted">
+      Host: <%= @match.host.username %> ·
+      <%= pluralize(@match.rounds_total, "round") %> ·
+      <%= @match.seconds_per_round %>s per round
+    </p>
+  </div>
+
+  <% if @match.status == "lobby" %>
+    <%# Share link %>
+    <div class="card px-5 py-4 space-y-2 border-forest-200">
+      <p class="text-sm font-semibold text-forest-800">Invite link</p>
+      <div class="flex items-center gap-2">
+        <code class="flex-1 text-xs bg-forest-50 border border-forest-200 rounded-lg px-3 py-2.5 text-forest-800 truncate select-all font-mono"><%= @share_url %></code>
+        <button type="button"
+                onclick="navigator.clipboard.writeText('<%= @share_url %>').then(() => { this.textContent = 'Copied!'; setTimeout(() => this.textContent = 'Copy', 1500) })"
+                class="btn-secondary text-sm py-2 shrink-0">Copy</button>
+      </div>
+      <p class="muted text-xs">Anyone with the link can join up to <%= Match::LOBBY_CAPACITY %> players.</p>
+    </div>
+
+    <%# Join / start CTA %>
+    <% if !@joined && @at_capacity %>
+      <div class="card px-5 py-4 text-center text-sm text-amber-700 bg-amber-50 border-amber-200">
+        Lobby is full (<%= Match::LOBBY_CAPACITY %> players). Ask the host to start.
+      </div>
+    <% elsif !@joined %>
+      <%= button_to "Join lobby", join_match_path(@match.code), method: :post,
+            class: "btn-primary w-full py-3 text-base" %>
+    <% elsif @is_host %>
+      <%= button_to "Start match (#{pluralize(@players.size, "player")})",
+            start_match_path(@match.code), method: :post,
+            class: "btn-primary w-full py-3 text-base",
+            disabled: !@can_start %>
+    <% else %>
+      <div class="card px-5 py-4 text-center text-sm text-forest-700">
+        Waiting for <strong><%= @match.host.username %></strong> to start the match…
+      </div>
+    <% end %>
+  <% elsif @match.status == "active" %>
+    <%# Game-play view ships in the next commit. For now, show a placeholder. %>
+    <div class="card px-5 py-6 text-center space-y-2">
+      <p class="text-sm font-semibold text-forest-800">Match in progress</p>
+      <p class="muted text-xs">The play view is being wired up — refresh shortly.</p>
+    </div>
+  <% else %>
+    <div class="card px-5 py-6 text-center">
+      <p class="text-sm font-semibold text-forest-800">Match finished</p>
+    </div>
+  <% end %>
+
+  <%# Player list %>
+  <section class="space-y-3">
+    <h2 class="heading-section">
+      Players (<%= @players.size %><%= "/#{Match::LOBBY_CAPACITY}" if @match.status == "lobby" %>)
+    </h2>
+    <div class="card overflow-hidden divide-y divide-forest-50">
+      <% @players.each do |player| %>
+        <div class="flex items-center gap-4 px-5 py-3.5 bg-white">
+          <span class="flex items-center gap-2 flex-1 min-w-0">
+            <img src="<%= player.user.gravatar_url(size: 40) %>" alt=""
+                 class="w-7 h-7 rounded-full shrink-0" width="40" height="40">
+            <span class="font-medium text-forest-900 truncate"><%= player.user.username %></span>
+            <% if @match.host_id == player.user_id %>
+              <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-forest-100 text-forest-700">Host</span>
+            <% end %>
+            <% if player.user_id == Current.user.id %>
+              <span class="text-xs text-gray-400">(you)</span>
+            <% end %>
+          </span>
+        </div>
+      <% end %>
+    </div>
+  </section>
+
+  <div class="flex items-center justify-between pt-2">
+    <%= link_to "Home", root_path, class: "btn-ghost" %>
+    <div class="flex items-center gap-2">
+      <% if @joined %>
+        <%= button_to "Leave", leave_match_path(@match.code), method: :post,
+              class: "btn-ghost text-amber-600 hover:text-amber-800",
+              data: { turbo_confirm: "Leave this lobby?" } %>
+      <% end %>
+      <% if @is_host %>
+        <%= button_to "Delete match", match_path(@match.code), method: :delete,
+              class: "btn-ghost text-red-500 hover:text-red-700",
+              data: { turbo_confirm: "Delete this match? This cannot be undone." } %>
+      <% end %>
+    </div>
+  </div>
+
+</div>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Lobby #{@match.code}" %>
 
-<div class="w-full max-w-xl mx-auto space-y-6 py-6">
+<div class="w-full max-w-5xl mx-auto space-y-6 py-6">
 
   <div class="space-y-1">
     <p class="eyebrow">Multiplayer · <%= @match.status.titleize %></p>
@@ -15,71 +15,71 @@
   </div>
 
   <% if @match.status == "lobby" %>
-    <%# Share link %>
-    <div class="card px-5 py-4 space-y-2 border-forest-200">
-      <p class="text-sm font-semibold text-forest-800">Invite link</p>
-      <div class="flex items-center gap-2">
-        <code class="flex-1 text-xs bg-forest-50 border border-forest-200 rounded-lg px-3 py-2.5 text-forest-800 truncate select-all font-mono"><%= @share_url %></code>
-        <button type="button"
-                onclick="navigator.clipboard.writeText('<%= @share_url %>').then(() => { this.textContent = 'Copied!'; setTimeout(() => this.textContent = 'Copy', 1500) })"
-                class="btn-secondary text-sm py-2 shrink-0">Copy</button>
-      </div>
-      <p class="muted text-xs">Anyone with the link can join up to <%= Match::LOBBY_CAPACITY %> players.</p>
-    </div>
-
-    <%# Join / start CTA %>
-    <% if !@joined && @at_capacity %>
-      <div class="card px-5 py-4 text-center text-sm text-amber-700 bg-amber-50 border-amber-200">
-        Lobby is full (<%= Match::LOBBY_CAPACITY %> players). Ask the host to start.
-      </div>
-    <% elsif !@joined %>
-      <%= button_to "Join lobby", join_match_path(@match.code), method: :post,
-            class: "btn-primary w-full py-3 text-base" %>
-    <% elsif @is_host %>
-      <%= button_to "Start match (#{pluralize(@players.size, "player")})",
-            start_match_path(@match.code), method: :post,
-            class: "btn-primary w-full py-3 text-base",
-            disabled: !@can_start %>
-    <% else %>
-      <div class="card px-5 py-4 text-center text-sm text-forest-700">
-        Waiting for <strong><%= @match.host.username %></strong> to start the match…
-      </div>
-    <% end %>
-  <% elsif @match.status == "active" %>
-    <%# Game-play view ships in the next commit. For now, show a placeholder. %>
-    <div class="card px-5 py-6 text-center space-y-2">
-      <p class="text-sm font-semibold text-forest-800">Match in progress</p>
-      <p class="muted text-xs">The play view is being wired up — refresh shortly.</p>
-    </div>
+    <%# === LOBBY === %>
+    <%= render "lobby" %>
   <% else %>
-    <div class="card px-5 py-6 text-center">
-      <p class="text-sm font-semibold text-forest-800">Match finished</p>
-    </div>
-  <% end %>
+    <%# === ACTIVE / FINISHED — polling client takes over === %>
+    <div data-controller="match-poll"
+         data-match-poll-state-url-value="<%= state_match_path(@match.code, format: :json) %>"
+         data-match-poll-guess-url-value="<%= guess_match_path(@match.code) %>"
+         data-match-poll-interval-ms-value="2000"
+         class="grid grid-cols-1 lg:grid-cols-3 gap-4">
 
-  <%# Player list %>
-  <section class="space-y-3">
-    <h2 class="heading-section">
-      Players (<%= @players.size %><%= "/#{Match::LOBBY_CAPACITY}" if @match.status == "lobby" %>)
-    </h2>
-    <div class="card overflow-hidden divide-y divide-forest-50">
-      <% @players.each do |player| %>
-        <div class="flex items-center gap-4 px-5 py-3.5 bg-white">
-          <span class="flex items-center gap-2 flex-1 min-w-0">
-            <img src="<%= player.user.gravatar_url(size: 40) %>" alt=""
-                 class="w-7 h-7 rounded-full shrink-0" width="40" height="40">
-            <span class="font-medium text-forest-900 truncate"><%= player.user.username %></span>
-            <% if @match.host_id == player.user_id %>
-              <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-forest-100 text-forest-700">Host</span>
-            <% end %>
-            <% if player.user_id == Current.user.id %>
-              <span class="text-xs text-gray-400">(you)</span>
-            <% end %>
+      <div class="lg:col-span-2 space-y-3">
+        <div class="flex items-center justify-between gap-2">
+          <h2 class="heading-section" data-match-poll-target="roundLabel">
+            <%= @match.current_round ? "Round #{@match.current_round.index} / #{@match.rounds_total}" : "Starting…" %>
+          </h2>
+          <span class="text-2xl font-bold tabular-nums text-forest-900" data-match-poll-target="timer">--s</span>
+        </div>
+
+        <div class="relative h-[55vh] flex items-center justify-center bg-gray-100 rounded-md border border-gray-200">
+          <img data-match-poll-target="image"
+               src="<%= @match.current_round ? image_src(@match.current_round.image, width: 1600) : '' %>"
+               alt="Guess this location"
+               class="max-w-full max-h-full object-contain">
+        </div>
+        <p class="text-xs text-gray-500" data-match-poll-target="imageTitle">
+          <%= @match.current_round&.image&.title %>
+        </p>
+
+        <%= render "shared/guess_map",
+              style: @match.image_set.map_style || "outdoor-v2",
+              class: "w-full h-[50vh]" %>
+
+        <div class="flex items-center gap-2">
+          <span data-match-poll-target="guessHint" class="text-sm text-gray-600">Click the map to drop your pin.</span>
+          <span data-match-poll-target="lockedBadge"
+                class="hidden text-sm font-semibold text-emerald-700 bg-emerald-50 border border-emerald-200 rounded-full px-3 py-0.5">
+            Locked in
           </span>
         </div>
-      <% end %>
+
+        <div data-match-poll-target="reveal" class="hidden card px-4 py-3 space-y-1"></div>
+
+        <div data-match-poll-target="finished" class="hidden card px-4 py-4 text-center bg-amber-50 border-amber-200">
+          <p class="font-semibold text-amber-700">Match finished!</p>
+          <p class="text-xs text-amber-700 mt-1">Final scores on the right.</p>
+        </div>
+      </div>
+
+      <aside class="space-y-3">
+        <div class="card overflow-hidden">
+          <div class="px-3 py-2 bg-forest-50 border-b border-forest-100 flex items-center justify-between">
+            <span class="text-xs font-semibold text-forest-800 uppercase tracking-wide">Scoreboard</span>
+            <span class="text-xs text-gray-500" data-match-poll-target="status"><%= @match.status %></span>
+          </div>
+          <div data-match-poll-target="scoreboard" class="divide-y divide-forest-50"></div>
+        </div>
+
+        <div class="card px-4 py-3 text-xs text-gray-500 space-y-1">
+          <div>Code: <code class="font-mono"><%= @match.code %></code></div>
+          <div>Host: <strong class="text-forest-700"><%= @match.host.username %></strong></div>
+          <div><%= pluralize(@match.rounds_total, "round") %>, <%= @match.seconds_per_round %>s each</div>
+        </div>
+      </aside>
     </div>
-  </section>
+  <% end %>
 
   <div class="flex items-center justify-between pt-2">
     <%= link_to "Home", root_path, class: "btn-ghost" %>
@@ -87,7 +87,7 @@
       <% if @joined %>
         <%= button_to "Leave", leave_match_path(@match.code), method: :post,
               class: "btn-ghost text-amber-600 hover:text-amber-800",
-              data: { turbo_confirm: "Leave this lobby?" } %>
+              data: { turbo_confirm: "Leave this match?" } %>
       <% end %>
       <% if @is_host %>
         <%= button_to "Delete match", match_path(@match.code), method: :delete,

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -22,6 +22,7 @@
     <div data-controller="match-poll"
          data-match-poll-state-url-value="<%= state_match_path(@match.code, format: :json) %>"
          data-match-poll-guess-url-value="<%= guess_match_path(@match.code) %>"
+         data-match-poll-results-url-value="<%= results_match_path(@match.code) %>"
          data-match-poll-interval-ms-value="2000"
          class="grid grid-cols-1 lg:grid-cols-3 gap-4">
 
@@ -57,9 +58,10 @@
 
         <div data-match-poll-target="reveal" class="hidden card px-4 py-3 space-y-1"></div>
 
-        <div data-match-poll-target="finished" class="hidden card px-4 py-4 text-center bg-amber-50 border-amber-200">
+        <div data-match-poll-target="finished" class="hidden card px-4 py-4 text-center bg-amber-50 border-amber-200 space-y-2">
           <p class="font-semibold text-amber-700">Match finished!</p>
-          <p class="text-xs text-amber-700 mt-1">Final scores on the right.</p>
+          <%= link_to "View final results →", results_match_path(@match.code),
+                class: "inline-block btn-primary text-sm" %>
         </div>
       </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,8 @@ Rails.application.routes.draw do
       post :join
       post :leave
       post :start
+      get  :state    # JSON snapshot for the polling client
+      post :guess    # JSON guess submission
     end
   end
   resources :images do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,15 @@ Rails.application.routes.draw do
     member { get :results }
     collection { get :leaderboard }
   end
+  # Multiplayer lobbies. URLs are keyed by short share code, not numeric id,
+  # so the entire join flow is "visit this link." See app/models/match.rb.
+  resources :matches, param: :code, only: %i[ new create show destroy ] do
+    member do
+      post :join
+      post :leave
+      post :start
+    end
+  end
   resources :images do
     collection { get :map }
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
       post :start
       get  :state    # JSON snapshot for the polling client
       post :guess    # JSON guess submission
+      get  :results  # final standings + per-round breakdown
     end
   end
   resources :images do

--- a/db/migrate/20260527190001_create_matches.rb
+++ b/db/migrate/20260527190001_create_matches.rb
@@ -1,0 +1,19 @@
+class CreateMatches < ActiveRecord::Migration[8.1]
+  def change
+    create_table :matches do |t|
+      t.references :host, null: false, foreign_key: { to_table: :users }
+      t.references :image_set, null: false, foreign_key: true
+      t.string   :status, null: false, default: "lobby"
+      t.string   :code, null: false
+      t.integer  :rounds_total, null: false, default: 5
+      t.integer  :seconds_per_round, null: false, default: 60
+      t.datetime :started_at
+      t.datetime :finished_at
+
+      t.timestamps
+    end
+
+    add_index :matches, :code, unique: true
+    add_index :matches, :status
+  end
+end

--- a/db/migrate/20260527190002_create_match_players.rb
+++ b/db/migrate/20260527190002_create_match_players.rb
@@ -1,0 +1,16 @@
+class CreateMatchPlayers < ActiveRecord::Migration[8.1]
+  def change
+    create_table :match_players do |t|
+      t.references :match, null: false, foreign_key: true
+      t.references :user,  null: false, foreign_key: true
+      t.datetime   :joined_at, null: false
+      t.datetime   :left_at
+      t.datetime   :forfeited_at
+      t.integer    :total_score, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :match_players, [ :match_id, :user_id ], unique: true
+  end
+end

--- a/db/migrate/20260527190003_create_match_rounds.rb
+++ b/db/migrate/20260527190003_create_match_rounds.rb
@@ -1,0 +1,18 @@
+class CreateMatchRounds < ActiveRecord::Migration[8.1]
+  def change
+    create_table :match_rounds do |t|
+      t.references :match, null: false, foreign_key: true
+      t.integer    :index, null: false
+      t.references :image, null: false, foreign_key: true
+      t.decimal    :answer_latitude,  precision: 10, scale: 6, null: false
+      t.decimal    :answer_longitude, precision: 10, scale: 6, null: false
+      t.datetime   :started_at, null: false
+      t.datetime   :deadline_at, null: false
+      t.datetime   :ended_at
+
+      t.timestamps
+    end
+
+    add_index :match_rounds, [ :match_id, :index ], unique: true
+  end
+end

--- a/db/migrate/20260527190004_create_match_guesses.rb
+++ b/db/migrate/20260527190004_create_match_guesses.rb
@@ -1,0 +1,20 @@
+class CreateMatchGuesses < ActiveRecord::Migration[8.1]
+  def change
+    create_table :match_guesses do |t|
+      t.references :match_round,  null: false, foreign_key: true
+      t.references :match_player, null: false, foreign_key: true
+      t.decimal    :latitude,  precision: 10, scale: 6, null: false
+      t.decimal    :longitude, precision: 10, scale: 6, null: false
+      t.decimal    :distance_km, precision: 12, scale: 3
+      t.integer    :score
+      t.datetime   :submitted_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :match_guesses,
+              [ :match_round_id, :match_player_id ],
+              unique: true,
+              name: "index_match_guesses_on_round_and_player"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_27_181429) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_27_190004) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -88,7 +88,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_181429) do
     t.bigint "challenger_id", null: false
     t.datetime "created_at", null: false
     t.bigint "image_set_id"
-    t.string "token", default: "", null: false
+    t.string "token", null: false
     t.datetime "updated_at", null: false
     t.index ["challenger_id"], name: "index_challenges_on_challenger_id"
     t.index ["image_set_id"], name: "index_challenges_on_image_set_id"
@@ -125,7 +125,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_181429) do
     t.datetime "created_at", null: false
     t.integer "duration_seconds"
     t.bigint "image_set_id"
-    t.float "score"
+    t.integer "score"
     t.string "status"
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
@@ -219,6 +219,68 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_181429) do
     t.index ["url"], name: "index_images_on_url", unique: true, where: "(url IS NOT NULL)"
   end
 
+  create_table "match_guesses", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.decimal "distance_km", precision: 12, scale: 3
+    t.decimal "latitude", precision: 10, scale: 6, null: false
+    t.decimal "longitude", precision: 10, scale: 6, null: false
+    t.bigint "match_player_id", null: false
+    t.bigint "match_round_id", null: false
+    t.integer "score"
+    t.datetime "submitted_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["match_player_id"], name: "index_match_guesses_on_match_player_id"
+    t.index ["match_round_id", "match_player_id"], name: "index_match_guesses_on_round_and_player", unique: true
+    t.index ["match_round_id"], name: "index_match_guesses_on_match_round_id"
+  end
+
+  create_table "match_players", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "forfeited_at"
+    t.datetime "joined_at", null: false
+    t.datetime "left_at"
+    t.bigint "match_id", null: false
+    t.integer "total_score", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["match_id", "user_id"], name: "index_match_players_on_match_id_and_user_id", unique: true
+    t.index ["match_id"], name: "index_match_players_on_match_id"
+    t.index ["user_id"], name: "index_match_players_on_user_id"
+  end
+
+  create_table "match_rounds", force: :cascade do |t|
+    t.decimal "answer_latitude", precision: 10, scale: 6, null: false
+    t.decimal "answer_longitude", precision: 10, scale: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "deadline_at", null: false
+    t.datetime "ended_at"
+    t.bigint "image_id", null: false
+    t.integer "index", null: false
+    t.bigint "match_id", null: false
+    t.datetime "started_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["image_id"], name: "index_match_rounds_on_image_id"
+    t.index ["match_id", "index"], name: "index_match_rounds_on_match_id_and_index", unique: true
+    t.index ["match_id"], name: "index_match_rounds_on_match_id"
+  end
+
+  create_table "matches", force: :cascade do |t|
+    t.string "code", null: false
+    t.datetime "created_at", null: false
+    t.datetime "finished_at"
+    t.bigint "host_id", null: false
+    t.bigint "image_set_id", null: false
+    t.integer "rounds_total", default: 5, null: false
+    t.integer "seconds_per_round", default: 60, null: false
+    t.datetime "started_at"
+    t.string "status", default: "lobby", null: false
+    t.datetime "updated_at", null: false
+    t.index ["code"], name: "index_matches_on_code", unique: true
+    t.index ["host_id"], name: "index_matches_on_host_id"
+    t.index ["image_set_id"], name: "index_matches_on_image_set_id"
+    t.index ["status"], name: "index_matches_on_status"
+  end
+
   create_table "regions", force: :cascade do |t|
     t.string "admin_level", null: false
     t.jsonb "boundary"
@@ -303,6 +365,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_181429) do
   add_foreign_key "image_set_tags", "tags"
   add_foreign_key "image_sets", "image_sets", column: "parent_image_set_id"
   add_foreign_key "image_sets", "users"
+  add_foreign_key "match_guesses", "match_players"
+  add_foreign_key "match_guesses", "match_rounds"
+  add_foreign_key "match_players", "matches"
+  add_foreign_key "match_players", "users"
+  add_foreign_key "match_rounds", "images"
+  add_foreign_key "match_rounds", "matches"
+  add_foreign_key "matches", "image_sets"
+  add_foreign_key "matches", "users", column: "host_id"
   add_foreign_key "regions", "regions", column: "parent_id"
   add_foreign_key "saved_practice_images", "images"
   add_foreign_key "saved_practice_images", "users"

--- a/docs/multiplayer-sketch.md
+++ b/docs/multiplayer-sketch.md
@@ -1,0 +1,324 @@
+# Multiplayer Sketch — Action Cable
+
+A starting blueprint for real-time multiplayer on top of the existing Rails app.
+Not a final design; meant to be argued with before any code lands.
+
+## Why Action Cable (not raw WebSockets / a separate service)
+
+- Already shipped with Rails — no new runtime, deploy target, or auth boundary.
+- Channels integrate with `current_user` via `ApplicationCable::Connection`.
+- Pairs cleanly with existing Stimulus controllers (`@rails/actioncable` client).
+- Trade-off: needs a Redis adapter in production for multi-process broadcasting.
+  Single-process dev uses the async adapter; no Redis needed locally.
+
+If we ever outgrow it (>thousands of concurrent rooms, sub-50ms tick rate), the
+escape hatch is a small Go/Elixir socket server reading from the same Postgres.
+Not worth designing for now.
+
+---
+
+## Data model
+
+Three new tables, all DB-authoritative. Action Cable only carries notifications.
+
+```
+matches
+  id, host_user_id, image_set_id, status (lobby|active|finished),
+  rounds_total, seconds_per_round, code (short joinable token),
+  started_at, finished_at, created_at
+
+match_players
+  id, match_id, user_id, joined_at, left_at, forfeited_at,
+  total_score
+  unique (match_id, user_id)
+
+match_rounds
+  id, match_id, index, image_id,
+  started_at, deadline_at, ended_at
+
+match_guesses
+  id, match_round_id, match_player_id, lat, lng, distance_m,
+  score, submitted_at
+  unique (match_round_id, match_player_id)
+```
+
+Single-player `Game`/`Guess` stay untouched — multiplayer is a parallel concept
+so we don't tangle scoring/leaderboard logic with real-time state.
+
+---
+
+## Channels
+
+### `ApplicationCable::Connection`
+
+Identify by `current_user` (reuse session cookie). Reject unauthenticated.
+
+### `MatchChannel`
+
+```
+class MatchChannel < ApplicationCable::Channel
+  def subscribed
+    @match = Match.find_by(code: params[:code])
+    return reject unless @match && @match.joinable_by?(current_user)
+    stream_for @match
+    MatchPresence.join(@match, current_user)   # broadcasts player_joined
+  end
+
+  def unsubscribed
+    MatchPresence.leave(@match, current_user)  # broadcasts player_left
+  end
+
+  # Client → server actions
+  def submit_guess(data)
+    SubmitGuess.call(match: @match, user: current_user,
+                     lat: data["lat"], lng: data["lng"])
+  end
+
+  def ready
+    LobbyReady.call(match: @match, user: current_user)
+  end
+end
+```
+
+Action methods are thin — they delegate to service objects that validate,
+persist, and broadcast. Keep the channel as a transport layer only.
+
+---
+
+## Server → client events
+
+All broadcast via `MatchChannel.broadcast_to(match, payload)`.
+Payloads are explicit so clients can be dumb.
+
+| Event             | When                                  | Payload (shape)                                     |
+| ----------------- | ------------------------------------- | --------------------------------------------------- |
+| `player_joined`   | new subscription                      | `{ user: {id, username, avatar_url} }`              |
+| `player_left`     | disconnect or explicit leave          | `{ user_id }`                                       |
+| `match_started`   | host starts, status → active          | `{ rounds_total, seconds_per_round }`               |
+| `round_started`   | each round begins                     | `{ index, image_url, deadline_at }`                 |
+| `player_guessed`  | someone locks in (no coords leaked)   | `{ user_id }`                                       |
+| `round_ended`     | timer hits zero OR everyone guessed   | `{ answer: {lat,lng}, guesses: [{user_id,lat,lng,distance_m,score}], scores: [{user_id,total}] }` |
+| `match_finished`  | last round ends                       | `{ final_scores: [...] }`                           |
+
+Critical: `player_guessed` carries **only** the user id, never coordinates.
+Coords are revealed atomically in `round_ended`.
+
+---
+
+## Round timing — server-side
+
+Don't trust client clocks. When a round starts:
+
+```
+round = match.match_rounds.create!(
+  index: i, image: next_image,
+  started_at: Time.current,
+  deadline_at: Time.current + match.seconds_per_round.seconds,
+)
+EndRoundJob.set(wait: match.seconds_per_round.seconds).perform_later(round.id)
+MatchChannel.broadcast_to(match, type: "round_started", ...)
+```
+
+`EndRoundJob` is idempotent: if every player already guessed, the "all submitted"
+path calls the same `EndRound.call(round)` service that no-ops on a finished
+round. Whichever fires first wins; the other becomes a cheap DB lookup.
+
+---
+
+## Reconnect / snapshot
+
+WebSocket delivers **deltas only**. On page load (or refresh mid-match), the
+client first fetches a snapshot via plain HTTP:
+
+```
+GET /matches/:code  →  { match, players, current_round, scores, server_now }
+```
+
+Then subscribes to the channel. `server_now` lets the client compute the
+round deadline as `deadline_at - (server_now - client_now)` to dodge clock skew.
+
+---
+
+## Stimulus controller — client skeleton
+
+```js
+// app/javascript/controllers/multiplayer_controller.js
+import { Controller } from "@hotwired/stimulus"
+import consumer from "../channels/consumer"
+
+export default class extends Controller {
+  static values = { code: String }
+  static targets = ["players", "image", "timer", "results"]
+
+  connect() {
+    this.subscription = consumer.subscriptions.create(
+      { channel: "MatchChannel", code: this.codeValue },
+      {
+        received: (msg) => this.dispatch(msg.type, { detail: msg }),
+      }
+    )
+  }
+
+  disconnect() { this.subscription?.unsubscribe() }
+
+  // dispatched events → handlers
+  onRoundStarted(e) { /* swap image, start countdown */ }
+  onPlayerGuessed(e) { /* mark avatar as "locked in" */ }
+  onRoundEnded(e) { /* reveal pins on map, show scores */ }
+  onMatchFinished(e) { /* navigate to results page */ }
+
+  submitGuess(e) {
+    this.subscription.perform("submit_guess",
+      { lat: e.detail.lat, lng: e.detail.lng })
+  }
+}
+```
+
+The existing `guess_map_controller.js` stays single-player-aware. Multiplayer
+mode is a sibling controller on the same page that listens for the map's
+`guess:submitted` event and forwards it over the socket.
+
+---
+
+## Open decisions (worth pinning down before coding)
+
+1. **Lockstep vs. async reveal.** End the round the moment the last player
+   guesses, or always wait for the timer? Lockstep feels snappier; timer-only
+   tolerates abandons gracefully. Probably: **end early if all *connected*
+   players have guessed, otherwise wait for timer.**
+
+2. **Disconnect policy.** If a player tabs out, do their unsubmitted rounds
+   score 0, or do they get a grace period? Suggest: 15s reconnect window before
+   marking `forfeited_at`.
+
+3. **Spectators.** Can non-players watch? If yes, they subscribe to a
+   read-only stream that filters out `player_guessed` until `round_ended`.
+
+4. **Bots / fill.** Out of scope for v1 — keep human-only.
+
+5. **Anti-cheat (low priority).** Server already enforces deadline + computes
+   distance. Only remaining vector is screen-sharing between players, which is
+   a social problem, not a technical one.
+
+---
+
+## Suggested build order
+
+1. **Schema + models** (`Match`, `MatchPlayer`, `MatchRound`, `MatchGuess`)
+   with associations + validations, no realtime yet.
+2. **Lobby flow over plain HTTP**: create match, share code, join, list players.
+   Verify model logic before introducing async surprises.
+3. **MatchChannel + presence broadcasts** (`player_joined` / `player_left`).
+   Simplest possible payloads, just to wire the transport.
+4. **Round lifecycle**: `match_started` → `round_started` → `round_ended` with
+   server-side timer job. Coords reveal only on round end.
+5. **Stimulus controller** with snapshot fetch + subscription. Hook into the
+   existing map controller.
+6. **Scoring + final leaderboard.** Reuse single-player scoring math.
+7. **Reconnect polish + forfeit timer.** Last because it's tuning, not core.
+
+Each step ships behind a feature flag (or just a route gate) until step 7.
+
+---
+
+## Alternative: Tier 3 — Polling, no WebSockets
+
+If Action Cable / Redis is more infrastructure than the project wants, the same
+data model and controller actions work with plain HTTP polling. Ship this first;
+upgrade to channels later without touching the schema.
+
+### What stays the same
+
+- All four tables (`matches`, `match_players`, `match_rounds`, `match_guesses`).
+- Service objects (`SubmitGuess`, `EndRound`, etc.) and their validation logic.
+- Server-side round timing (still need `EndRoundJob` so the round closes even
+  when no one is polling).
+
+### What changes
+
+- **No `MatchChannel`, no broadcasts, no Redis.**
+- **One JSON endpoint** that returns the full client-visible state:
+
+  ```
+  GET /matches/:code/state.json
+    → {
+        server_now: "...",
+        match: { status, round_index, rounds_total },
+        current_round: { index, image_url, deadline_at, my_guess_submitted },
+        players: [{ id, username, avatar_url, locked_in, total_score }],
+        last_round_result: null | { answer:{lat,lng}, guesses:[...], scores:[...] }
+      }
+  ```
+
+  Same payload shape as the "snapshot + deltas" approach, just delivered every
+  tick instead of once on load. **Never leak unguessed coords** — the controller
+  filters `last_round_result` to `null` until the round has actually ended.
+
+- **Submits stay POST:** `POST /matches/:code/guesses` with `{lat,lng}`.
+
+### Client — two options, both tiny
+
+**(a) Turbo Frame auto-refresh** — zero JS:
+
+```erb
+<%= turbo_frame_tag "match_state", src: match_state_path(@match),
+                                   refresh: "2s" %>
+```
+
+The frame re-fetches every 2 seconds and swaps its contents. Good when the
+"changing" region of the page is a contained block (player list, scoreboard).
+Awkward when you also need to drive a Leaflet map — Turbo replaces the DOM and
+you lose the map instance.
+
+**(b) Stimulus controller with `setInterval`** — ~20 lines:
+
+```js
+// app/javascript/controllers/match_poll_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { url: String, intervalMs: { type: Number, default: 2000 } }
+
+  connect() {
+    this.tick()
+    this.timer = setInterval(() => this.tick(), this.intervalMsValue)
+  }
+
+  disconnect() { clearInterval(this.timer) }
+
+  async tick() {
+    const res = await fetch(this.urlValue, { headers: { Accept: "application/json" }})
+    if (!res.ok) return
+    const state = await res.json()
+    this.dispatch("update", { detail: state })  // map/scoreboard listen
+  }
+}
+```
+
+The map controller listens for `match-poll:update` and reconciles pins / round
+state itself. Keeps Leaflet instance alive across polls.
+
+### Tuning
+
+- **Interval:** 2s feels real-time enough for a guessing game; 1s if you want
+  snappier "X locked in" badges. Don't go below 1s — server load scales
+  linearly.
+- **Backoff:** pause polling when `document.hidden` (tab in background) to
+  avoid wasted requests.
+- **ETag the endpoint** so unchanged polls return `304 Not Modified` and skip
+  rendering. One line in the controller; halves server CPU.
+- **Conditional polling cadence:** poll every 2s during a round, every 5s in
+  the lobby, stop entirely after `match_finished`.
+
+### When to upgrade to Action Cable
+
+Concrete signals, not vibes:
+
+- Polling traffic > a noticeable fraction of total request volume in logs.
+- Players complain about reveal lag (>2s feels sluggish on a fast round).
+- You want server-pushed events the client can't predict the timing of
+  (e.g. host kicks a player mid-round).
+
+Upgrade is mechanical: keep the JSON endpoint as the snapshot route, add
+`MatchChannel` for deltas, swap the Stimulus `setInterval` for a subscription.
+Service objects and schema don't move.


### PR DESCRIPTION
## Summary

  Adds real-time multiplayer matches alongside (not replacing) the single-player
  flow. Players join by sharing a link; the host starts when the lobby has
  1–100 people. Built on HTTP polling — no Action Cable, no Redis, no new
  infra.

  ## Mechanism

  ### Why polling, not WebSockets
  The sketch in `docs/multiplayer-sketch.md` weighs Action Cable vs. polling
  (Tier 3) and we picked polling: it touches zero existing infrastructure,
  ships in dev with no Redis, and has a clean upgrade path (the JSON snapshot
  becomes the Action Cable reconnect payload later — schema and services don't
  move).

  ### End-to-end flow

  1. **Lobby (`/matches/:code`)** — server-rendered. A small Stimulus
     controller (`match-lobby-poll`) hits `GET /matches/:code/state.json`
     every 2s, rewrites the player list innerHTML, and `window.location.reload()`s
     when `state.match.status != "lobby"` so the play view takes over
     automatically when the host clicks **Start**.

  2. **Round lifecycle** — server-authoritative.
     `MatchStartRound` picks a random unused image from the match's set,
     stamps `started_at` + `deadline_at`, and enqueues `EndMatchRoundJob`
     with `wait: seconds_per_round`. The job is idempotent under a row lock;
     the "everyone-guessed" early-end path calls the same `MatchEndRound`
     service, so whichever fires first wins and the other becomes a no-op.
     `MatchEndRound` scores guesses via `Game.haversine_km` +
     `Game.geoguessr_round_score` (reused, never duplicated), then either
     calls `MatchStartRound` for the next round or marks the match finished.

  3. **Play view** — `match-poll` polls the same `state.json` endpoint,
     diffs against what's on screen, and:
     - swaps the image + resets the existing `guess-map` controller when
       `current_round.index` changes,
     - locks the map when `my_guess_submitted` flips true,
     - reveals the answer + every player's pin atomically when
       `last_round_result` appears,
     - re-renders the scoreboard.

     The map controller is **not forked** — multiplayer adds a sibling
     Stimulus controller that listens for the existing `guess-map:pinned`
     event and POSTs to `/matches/:code/guess`.

  4. **Clock drift** — every poll stamps `server_now`; the client stores
     `Date.now() - Date.parse(server_now)` as `serverOffsetMs` and computes
     round-remaining as `deadline_at - (Date.now() - serverOffsetMs)`. No
     reliance on client clocks.

  ### Anti-cheat
  - `state.json#current_round` carries the image URL and deadline but
    **never** the answer or other players' guess coords. The reveal only
    ships in `last_round_result`, which is only populated after the round
    is `ended_at`-stamped.
  - The `player_locked_in` flag is derived from the guess table — clients
    see "X submitted" without learning where X pinned.

  ## Data model

  Four new tables, parallel to single-player so scoring/leaderboard logic
  can't entangle:

  - `matches` — host_user, image_set, status (lobby|active|finished), short
    Crockford-ish code (no 0/O/1/I), rounds_total, seconds_per_round.
  - `match_players` — unique (match, user); `left_at` / `forfeited_at` /
    running `total_score`.
  - `match_rounds` — image + answer coords + server-side `deadline_at`,
    unique (match, index).
  - `match_guesses` — unique (round, player), scored after `ended_at`.

  ## Constraints

  - **Lobby cap**: `Match::LOBBY_CAPACITY = 100`. `joinable_by?` and
    `startable_by?` both gate on it; host start button is disabled past
    the cap.
  - **Share-link only**: no public lobby index, no discovery. The match
    URL *is* the join mechanism.
  - **No spectators yet**: state.json works for non-players but guess
    submission 403s.

  ## What's not in this PR

  - 15-second reconnect-grace forfeit timer (sketch item).
  - Per-round map-of-all-pins on the results page (the current results
    table is per-cell score + distance only).
  - ETag on `state.json` (one-line cache win, easy follow-up).

  ## Test plan

  - [ ] `bin/rails db:migrate` runs cleanly (four new migrations).
  - [ ] Sign in, visit **Multiplayer** in the nav → `/matches/new`, create
        a match.
  - [ ] Open the share link in a second browser as another user; **first**
        browser sees the new player within ~2s without refreshing.
  - [ ] Host **Start match** — both browsers auto-advance to the play view.
  - [ ] Each player drops a pin; round closes when both guess (or when the
        timer hits zero, whichever first); answer + pins reveal atomically.
  - [ ] After the last round, **View final results →** lands on the
        per-round breakdown with correct totals.
  - [ ] Non-host clicking Start: 403 / redirected with a flash alert.
  - [ ] Joining past 100 players: rejected with "Lobby is full".
  - [ ] `MatchEndRound` called twice on the same round (race) doesn't
        double-score.