### PR TITLE
Hide image title during multiplayer rounds

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -229,12 +229,13 @@ class MatchesController < ApplicationController
   # Per-round payload while the round is still live. Critical: NEVER include
   # the answer coords here, and don't echo other players' guess coords —
   # those reveal atomically in build_last_round_result once the round ends.
+  # The image title is also withheld: it can name the location and give the
+  # answer away. The title is only shown afterward on the match results page.
   def build_current_round_payload(round, player)
     return nil if round.nil? || round.ended?
     {
       index:        round.index,
       image_url:    helpers.image_src(round.image, width: 1600),
-      image_title:  round.image.title,
       started_at:   round.started_at.iso8601(3),
       deadline_at:  round.deadline_at.iso8601(3),
       my_guess_submitted: player.present? &&

--- a/app/javascript/controllers/match_poll_controller.js
+++ b/app/javascript/controllers/match_poll_controller.js
@@ -15,7 +15,7 @@ export default class extends Controller {
     intervalMs: { type: Number, default: 2000 }
   }
   static targets = [
-    "image", "imageTitle", "roundLabel", "timer", "status",
+    "image", "roundLabel", "timer", "status",
     "scoreboard", "reveal", "guessHint", "lockedBadge", "finished"
   ]
 
@@ -85,7 +85,6 @@ export default class extends Controller {
       }
 
       if (this.hasImageTarget)      this.imageTarget.src = cr.image_url
-      if (this.hasImageTitleTarget) this.imageTitleTarget.textContent = cr.image_title || ""
       if (this.hasRoundLabelTarget) {
         this.roundLabelTarget.textContent = `Round ${cr.index} / ${state.match.rounds_total}`
       }

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -40,9 +40,6 @@
                alt="Guess this location"
                class="max-w-full max-h-full object-contain">
         </div>
-        <p class="text-xs text-gray-500" data-match-poll-target="imageTitle">
-          <%= @match.current_round&.image&.title %>
-        </p>
 
         <%= render "shared/guess_map",
               style: @match.image_set.map_style || "outdoor-v2",


### PR DESCRIPTION
The image title can name the location and give away the answer in the location-guessing game. This removes it from the live multiplayer round in all three places it leaked: the view, the `state.json` payload, and the poll controller's JS. The title still shows on the match results page after the match ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)